### PR TITLE
Update lote status RPC usage and buyer details update

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -221,7 +221,7 @@ export function MapView({
     try {
       const { error } = await supabase.rpc('update_lote_status', {
         p_lote_id: loteId,
-        p_status: newStatus
+        p_novo_status: newStatus
       });
 
       if (error) {


### PR DESCRIPTION
## Summary
- Switch MapView and admin sales page to use `p_novo_status` when calling `update_lote_status`
- Split buyer details and price update from status change using direct `lotes` update

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01cf66884832aabda663942b241ff