### PR TITLE
Fix lot loading by using correct RPC parameter

### DIFF
--- a/src/pages/admin/MapaReal.tsx
+++ b/src/pages/admin/MapaReal.tsx
@@ -150,7 +150,7 @@ function MapView({ selected }: { selected?: Empreendimento }) {
     (async () => {
       try {        
         // Load lotes via RPC
-        const { data: fc, error: lotesError } = await supabase.rpc('lotes_geojson', { p_empreendimento: selected.id });
+        const { data: fc, error: lotesError } = await supabase.rpc('lotes_geojson', { p_empreendimento_id: selected.id });
         
         if (!lotesError && fc) {
           // Remove previous lots layer


### PR DESCRIPTION
## Summary
- fix `lotes_geojson` RPC call to use `p_empreendimento_id` parameter so lots load correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 71 errors, 28 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01cfb0d78832aa81ce7e33c2e5aaf