### PR TITLE
fix: use p_reason param when rejecting empreendimentos

### DIFF
--- a/src/pages/admin/AprovacaoEmpreendimentos.tsx
+++ b/src/pages/admin/AprovacaoEmpreendimentos.tsx
@@ -99,7 +99,7 @@ export default function AprovacaoEmpreendimentos() {
       const { error } = await supabase.rpc('approve_empreendimento', {
         p_empreendimento_id: id,
         p_approved: false,
-        p_rejection_reason: rejectionReason
+        p_reason: rejectionReason
       });
 
       if (error) throw error;


### PR DESCRIPTION
## Summary
- use updated `p_reason` param in AprovacaoEmpreendimentos rejection flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68a01cfd1aa8832a8ab512594384d9cf