### PR TITLE
Use admin-filial path for admin login flows

### DIFF
--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Crown, User, Settings, Zap } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
+import { scopeRoutes } from "@/config/authConfig";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
 interface QuickLoginCredential {
@@ -16,18 +17,102 @@ interface QuickLoginCredential {
 }
 
 const allCredentials: QuickLoginCredential[] = [
-  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
-  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
-  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
-  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
-  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
-  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
-  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
-  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
-  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
-  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
-  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
-  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
+  {
+    email: 'superadmin@blockurb.com',
+    password: 'BlockUrb2024!',
+    label: 'Super Admin',
+    role: 'superadmin',
+    panel: scopeRoutes.superadmin,
+    icon: Crown,
+  },
+  {
+    email: 'admin@blockurb.com',
+    password: 'Admin2024!',
+    label: 'Admin Filial',
+    role: 'admin',
+    panel: scopeRoutes.admin,
+    icon: User,
+  },
+  {
+    email: 'urbanista@blockurb.com',
+    password: 'Urban2024!',
+    label: 'Urbanista',
+    role: 'urbanista',
+    panel: '/urbanista',
+    icon: User,
+  },
+  {
+    email: 'juridico@blockurb.com',
+    password: 'Legal2024!',
+    label: 'Jurídico',
+    role: 'juridico',
+    panel: scopeRoutes.juridico,
+    icon: User,
+  },
+  {
+    email: 'contabilidade@blockurb.com',
+    password: 'Conta2024!',
+    label: 'Contabilidade',
+    role: 'contabilidade',
+    panel: scopeRoutes.contabilidade,
+    icon: User,
+  },
+  {
+    email: 'marketing@blockurb.com',
+    password: 'Market2024!',
+    label: 'Marketing',
+    role: 'marketing',
+    panel: scopeRoutes.marketing,
+    icon: User,
+  },
+  {
+    email: 'comercial@blockurb.com',
+    password: 'Venda2024!',
+    label: 'Comercial',
+    role: 'comercial',
+    panel: scopeRoutes.comercial,
+    icon: User,
+  },
+  {
+    email: 'imobiliaria@blockurb.com',
+    password: 'Imob2024!',
+    label: 'Imobiliária',
+    role: 'imobiliaria',
+    panel: scopeRoutes.imobiliaria,
+    icon: User,
+  },
+  {
+    email: 'corretor@blockurb.com',
+    password: 'Corret2024!',
+    label: 'Corretor',
+    role: 'corretor',
+    panel: scopeRoutes.corretor,
+    icon: User,
+  },
+  {
+    email: 'obras@blockurb.com',
+    password: 'Obras2024!',
+    label: 'Obras',
+    role: 'obras',
+    panel: scopeRoutes.obras,
+    icon: User,
+  },
+  {
+    email: 'investidor@blockurb.com',
+    password: 'Invest2024!',
+    label: 'Investidor',
+    role: 'investidor',
+    panel: scopeRoutes.investidor,
+    icon: User,
+  },
+  {
+    email: 'terrenista@blockurb.com',
+    password: 'Terra2024!',
+    label: 'Terrenista',
+    role: 'terrenista',
+    panel: scopeRoutes.terrenista,
+    icon: User,
+  },
 ];
 
 interface QuickLoginWidgetProps {

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Eye, EyeOff, Crown, User } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { scopeRoutes } from "@/config/authConfig";
 
 export interface LoginFormProps {
   title: string;
@@ -38,7 +39,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || scopeRoutes.admin);
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");
@@ -63,7 +64,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || scopeRoutes.admin);
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");


### PR DESCRIPTION
## Summary
- point quick login admin panel to `/admin-filial`
- redirect logged-in users to `/admin-filial` by default
- centralize quick-login panel paths using `scopeRoutes`

## Testing
- `npm run lint` *(fails: Unexpected any, require import restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a023627c4c832a8142cce2b60e0c6e