### PR TITLE
feat: gate quick login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ npm i
 npm run dev
 ```
 
+### Quick development logins
+
+The application includes an optional quick-login widget for local development. To enable it, create a `.env.local` file and set:
+
+```
+VITE_ENABLE_DEV_LOGIN=true
+```
+
+When this flag is not set, the quick-login UI and its credentials are excluded from the production build.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -1,34 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Crown, User, Settings, Zap } from "lucide-react";
+import { Settings, Zap } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-
-interface QuickLoginCredential {
-  email: string;
-  password: string;
-  label: string;
-  role: string;
-  panel: string;
-  icon: any;
-}
-
-const allCredentials: QuickLoginCredential[] = [
-  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
-  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
-  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
-  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
-  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
-  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
-  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
-  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
-  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
-  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
-  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
-  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
-];
+import type { DevCredential } from "@/config/devCredentials";
 
 interface QuickLoginWidgetProps {
   compact?: boolean;
@@ -39,9 +16,20 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [credentials, setCredentials] = useState<DevCredential[]>([]);
   const navigate = useNavigate();
 
-  const quickLogin = async (cred: QuickLoginCredential) => {
+  useEffect(() => {
+    if (import.meta.env.VITE_ENABLE_DEV_LOGIN) {
+      import("@/config/devCredentials").then((m) => setCredentials(m.devCredentials));
+    }
+  }, []);
+
+  if (!import.meta.env.VITE_ENABLE_DEV_LOGIN || credentials.length === 0) {
+    return null;
+  }
+
+  const quickLogin = async (cred: DevCredential) => {
     setError(null);
     setLoading(cred.email);
     
@@ -83,7 +71,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
           <Card className="border-dashed border-2 border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20">
             <CardContent className="p-3">
               <div className="grid gap-1 max-h-60 overflow-y-auto">
-                {allCredentials.map((cred, index) => {
+                {credentials.map((cred, index) => {
                   const IconComponent = cred.icon;
                   const isLoading = loading === cred.email;
                   
@@ -122,7 +110,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
       </CardHeader>
       <CardContent className="pt-0">
         <div className="grid gap-2 max-h-64 overflow-y-auto">
-          {allCredentials.map((cred, index) => {
+          {credentials.map((cred, index) => {
             const IconComponent = cred.icon;
             const isLoading = loading === cred.email;
             

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,12 +1,13 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Eye, EyeOff, Crown, User } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { DevCredential } from "@/config/devCredentials";
 
 export interface LoginFormProps {
   title: string;
@@ -74,26 +75,13 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
 
   const preserve = scope ? `?scope=${encodeURIComponent(scope)}` : '';
 
-  // Credenciais de teste para desenvolvimento
-  const getQuickLoginCredentials = () => {
-    // Retorna a lista completa de todos os usuários, ignorando o 'scope' da página.
-    return [
-      { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', icon: Crown },
-      { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', icon: User },
-      { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', icon: User },
-      { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', icon: User },
-      { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', icon: User },
-      { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', icon: User },
-      { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', icon: User },
-      { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', icon: User },
-      { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', icon: User },
-      { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', icon: User },
-      { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', icon: User },
-      { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', icon: User },
-    ];
-  };
+  const [quickCredentials, setQuickCredentials] = useState<DevCredential[]>([]);
 
-  const quickCredentials = getQuickLoginCredentials();
+  useEffect(() => {
+    if (import.meta.env.VITE_ENABLE_DEV_LOGIN) {
+      import("@/config/devCredentials").then((m) => setQuickCredentials(m.devCredentials));
+    }
+  }, []);
 
   return (
     <div className="space-y-6">

--- a/src/config/devCredentials.ts
+++ b/src/config/devCredentials.ts
@@ -1,0 +1,25 @@
+import { Crown, User, type LucideIcon } from "lucide-react";
+
+export interface DevCredential {
+  email: string;
+  password: string;
+  label: string;
+  icon: LucideIcon;
+  role?: string;
+  panel?: string;
+}
+
+export const devCredentials: DevCredential[] = [
+  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
+  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
+  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
+  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
+  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
+  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
+  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
+  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
+  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
+  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
+  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
+  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
+];


### PR DESCRIPTION
## Summary
- move development credentials to dedicated config gated by `VITE_ENABLE_DEV_LOGIN`
- load quick login UI only when the dev flag is enabled
- document the `VITE_ENABLE_DEV_LOGIN` flag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0236e7e74832a80a5e0bf848a665a