### PR TITLE
refactor: centralize quick login credentials

### DIFF
--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -1,34 +1,11 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Crown, User, Settings, Zap } from "lucide-react";
+import { Settings, Zap } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-
-interface QuickLoginCredential {
-  email: string;
-  password: string;
-  label: string;
-  role: string;
-  panel: string;
-  icon: any;
-}
-
-const allCredentials: QuickLoginCredential[] = [
-  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
-  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
-  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
-  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
-  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
-  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
-  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
-  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
-  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
-  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
-  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
-  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
-];
+import { quickLoginCredentials, type QuickLoginCredential } from "@/config/quickLogin";
 
 interface QuickLoginWidgetProps {
   compact?: boolean;
@@ -83,7 +60,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
           <Card className="border-dashed border-2 border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20">
             <CardContent className="p-3">
               <div className="grid gap-1 max-h-60 overflow-y-auto">
-                {allCredentials.map((cred, index) => {
+                {quickLoginCredentials.map((cred, index) => {
                   const IconComponent = cred.icon;
                   const isLoading = loading === cred.email;
                   
@@ -122,7 +99,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
       </CardHeader>
       <CardContent className="pt-0">
         <div className="grid gap-2 max-h-64 overflow-y-auto">
-          {allCredentials.map((cred, index) => {
+          {quickLoginCredentials.map((cred, index) => {
             const IconComponent = cred.icon;
             const isLoading = loading === cred.email;
             

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -3,7 +3,8 @@ import { useForm } from "react-hook-form";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Eye, EyeOff, Crown, User } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
+import { quickLoginCredentials } from "@/config/quickLogin";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -75,25 +76,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
   const preserve = scope ? `?scope=${encodeURIComponent(scope)}` : '';
 
   // Credenciais de teste para desenvolvimento
-  const getQuickLoginCredentials = () => {
-    // Retorna a lista completa de todos os usuários, ignorando o 'scope' da página.
-    return [
-      { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', icon: Crown },
-      { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', icon: User },
-      { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', icon: User },
-      { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', icon: User },
-      { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', icon: User },
-      { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', icon: User },
-      { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', icon: User },
-      { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', icon: User },
-      { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', icon: User },
-      { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', icon: User },
-      { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', icon: User },
-      { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', icon: User },
-    ];
-  };
-
-  const quickCredentials = getQuickLoginCredentials();
+  const quickCredentials = quickLoginCredentials;
 
   return (
     <div className="space-y-6">

--- a/src/config/quickLogin.ts
+++ b/src/config/quickLogin.ts
@@ -1,0 +1,26 @@
+import { Crown, User, type LucideIcon } from "lucide-react";
+
+export interface QuickLoginCredential {
+  email: string;
+  password: string;
+  label: string;
+  role: string;
+  panel: string;
+  icon: LucideIcon;
+}
+
+export const quickLoginCredentials: QuickLoginCredential[] = [
+  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
+  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
+  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
+  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
+  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
+  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
+  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
+  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
+  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
+  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
+  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
+  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
+];
+


### PR DESCRIPTION
## Summary
- centralize quick login credentials in config and reuse across widgets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 98 problems (70 errors))*

------
https://chatgpt.com/codex/tasks/task_e_68a02373d27c832abfa3b57763b0c5e8