### PR TITLE
Add safety checks for scope helper functions

### DIFF
--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -30,14 +30,24 @@ const scopeLabels: Record<AuthScope, string> = {
   terrenista: "Terrenista",
 };
 
-export function labelFromScope(scope?: string | null) {
+export function labelFromScope(scope?: string | null): string | undefined {
   if (!scope) return undefined;
-  const key = scope.toLowerCase() as AuthScope;
-  return (scopeLabels as any)[key] as string | undefined;
+
+  const key = scope.toLowerCase();
+  if (key in scopeLabels) {
+    return scopeLabels[key as AuthScope];
+  }
+
+  return undefined;
 }
 
-export function pathFromScope(scope?: string | null) {
+export function pathFromScope(scope?: string | null): string {
   if (!scope) return "/acessos";
-  const key = scope.toLowerCase() as AuthScope;
-  return (scopeRoutes as any)[key] ?? "/acessos";
+
+  const key = scope.toLowerCase();
+  if (key in scopeRoutes) {
+    return scopeRoutes[key as AuthScope];
+  }
+
+  return "/acessos";
 }


### PR DESCRIPTION
## Summary
- guard labelFromScope and pathFromScope against unknown keys
- return undefined or default path when scope lookup fails

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02378bbf0832a89ce2adff5ae5f44