### PR TITLE
refactor: type lucide icons

### DIFF
--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Crown, User, Settings, Zap } from "lucide-react";
+import { Crown, User, Settings, Zap, type LucideIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -12,7 +12,7 @@ interface QuickLoginCredential {
   label: string;
   role: string;
   panel: string;
-  icon: any;
+  icon: LucideIcon;
 }
 
 const allCredentials: QuickLoginCredential[] = [
@@ -84,7 +84,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
             <CardContent className="p-3">
               <div className="grid gap-1 max-h-60 overflow-y-auto">
                 {allCredentials.map((cred, index) => {
-                  const IconComponent = cred.icon;
+                  const IconComponent: LucideIcon = cred.icon;
                   const isLoading = loading === cred.email;
                   
                   return (
@@ -123,7 +123,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
       <CardContent className="pt-0">
         <div className="grid gap-2 max-h-64 overflow-y-auto">
           {allCredentials.map((cred, index) => {
-            const IconComponent = cred.icon;
+            const IconComponent: LucideIcon = cred.icon;
             const isLoading = loading === cred.email;
             
             return (

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Eye, EyeOff, Crown, User } from "lucide-react";
+import { Eye, EyeOff, Crown, User, type LucideIcon } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -108,7 +108,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
           <CardContent className="pt-0">
             <div className="grid gap-2">
               {quickCredentials.map((cred, index) => {
-                const IconComponent = cred.icon;
+                const IconComponent: LucideIcon = cred.icon;
                 return (
                   <Button
                     key={index}


### PR DESCRIPTION
## Summary
- use `LucideIcon` type for quick login credentials
- ensure icon components are typed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0237cf084832aa2dfb7d0f4d2ec33