### PR TITLE
feat: isolate filial data and enforce rls

### DIFF
--- a/src/components/app/VincularClienteSaas.tsx
+++ b/src/components/app/VincularClienteSaas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/dataClient";
+import { useAuth } from "@/providers/AuthProvider";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
@@ -29,14 +30,19 @@ export default function VincularClienteSaas({ filiais, onVincular }: Props) {
   const [userId, setUserId] = useState("");
   const [filialId, setFilialId] = useState("");
   const [saving, setSaving] = useState(false);
+  const { profile } = useAuth();
 
   useEffect(() => {
     async function fetchUsers() {
       setLoading(true);
-      const { data, error } = await supabase
+      let query = supabase
         .from("user_profiles")
         .select("user_id, full_name, email, filial_id, role")
         .order("full_name", { ascending: true });
+      if (profile?.filial_id && profile.role !== "superadmin") {
+        query = query.eq("filial_id", profile.filial_id);
+      }
+      const { data, error } = await query;
       if (error) {
         toast.error("Erro ao buscar usuários: " + error.message);
       } else {
@@ -45,7 +51,7 @@ export default function VincularClienteSaas({ filiais, onVincular }: Props) {
       setLoading(false);
     }
     fetchUsers();
-  }, []);
+  }, [profile?.filial_id]);
 
   const handleVincular = async () => {
     if (!userId || !filialId) {

--- a/src/pages/admin/Mapa.tsx
+++ b/src/pages/admin/Mapa.tsx
@@ -49,7 +49,8 @@ const fetchEmpreendimentos = async (filialId?: string | null): Promise<Emp[]> =>
     const { data: empRows, error: empError } = await supabase
       .from('empreendimentos')
       .select('id, nome, bounds, geojson_url, masterplan_url')
-      .in('id', ids);
+      .in('id', ids)
+      .eq('filial_id', filialId);
     if (empError) {
       console.error("Erro ao buscar empreendimentos:", empError);
       return [];
@@ -243,6 +244,7 @@ function MapView({ selected }: { selected?: Emp }) {
                                     .from('lotes')
                                     .select('id, nome, numero, status, area_m2, perimetro_m, area_hectares, valor') // Adiciona 'valor'
                                     .eq('id', p.id)
+                                    .eq('filial_id', profile?.filial_id || '')
                                     .single();
                                 
                                 if (error) throw error;

--- a/src/pages/admin/MapaInterativo.tsx
+++ b/src/pages/admin/MapaInterativo.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { MapView } from "@/components/MapView";
 import { supabase } from "@/lib/dataClient";
+import { useAuth } from "@/providers/AuthProvider";
 import { LoteData } from "@/lib/geojsonUtils";
 import { RefreshCw, Search, TrendingUp } from "lucide-react";
 
@@ -40,15 +41,18 @@ export default function MapaInterativo() {
   const [selectedLote, setSelectedLote] = useState<LoteData | null>(null);
   const [stats, setStats] = useState<VendasStats | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const { profile } = useAuth();
 
   // Carregar empreendimentos
   const loadEmpreendimentos = async () => {
     try {
+      if (!profile?.filial_id) return;
       setLoading(true);
       const { data, error } = await supabase
         .from('empreendimentos')
         .select('*')
         .eq('status', 'aprovado')
+        .eq('filial_id', profile.filial_id)
         .order('created_at', { ascending: false });
 
       if (error) {
@@ -57,7 +61,7 @@ export default function MapaInterativo() {
       }
 
       setEmpreendimentos(data || []);
-      
+
       // Selecionar primeiro empreendimento automaticamente
       if (data && data.length > 0 && !selectedEmp) {
         setSelectedEmp(data[0].id);
@@ -91,7 +95,7 @@ export default function MapaInterativo() {
 
   useEffect(() => {
     loadEmpreendimentos();
-  }, []);
+  }, [profile?.filial_id]);
 
   useEffect(() => {
     if (selectedEmp) {

--- a/src/pages/admin/MapaReal.tsx
+++ b/src/pages/admin/MapaReal.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import L, { LatLngBoundsExpression, Layer } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { supabase } from "@/lib/dataClient";
+import { useAuth } from "@/providers/AuthProvider";
 
 // Interface para empreendimentos do Supabase
 interface Empreendimento {
@@ -25,20 +26,23 @@ function SidebarEmpreendimentos({ onSelect, activeId }: { onSelect: (e: Empreend
   const [periodo, setPeriodo] = useState("7");
   const [empreendimentos, setEmpreendimentos] = useState<Empreendimento[]>([]);
   const [loading, setLoading] = useState(true);
+  const { profile } = useAuth();
 
   useEffect(() => {
     (async () => {
+      if (!profile?.filial_id) { setLoading(false); return; }
       const { data, error } = await supabase
         .from('empreendimentos')
         .select('id, nome, created_at')
+        .eq('filial_id', profile.filial_id)
         .order('created_at', { ascending: false });
-      
+
       if (!error && data) {
         setEmpreendimentos(data);
       }
       setLoading(false);
     })();
-  }, []);
+  }, [profile?.filial_id]);
 
   const filtered = useMemo(() => {
     return empreendimentos.filter(e => e.nome.toLowerCase().includes(q.toLowerCase()));


### PR DESCRIPTION
## Summary
- add filial_id columns and RLS policies to lotes and masterplan overlays
- filter Supabase queries by current filial
- guard component queries to fetch users from same filial

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npx eslint src/pages/admin/Lotes.tsx src/pages/admin/LotesVendas.tsx src/pages/admin/MapaInterativo.tsx src/pages/admin/MapaReal.tsx src/pages/admin/Mapa.tsx src/components/app/VincularClienteSaas.tsx` *(fails: Unexpected any and missing deps warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a02eb06914832a856d0c572385d8a7