### PR TITLE
Add user-specific panel permissions

### DIFF
--- a/app.final.sql
+++ b/app.final.sql
@@ -475,6 +475,13 @@ begin
   update public.user_profiles set filial_id = p_filial_id, updated_at = now() where user_id = p_user_id;
 end $$;
 
+create or replace function public.admin_set_user_panels(p_user_id uuid, p_panels text[])
+returns void language plpgsql as $$
+begin
+  if not public.is_admin(auth.uid()) then raise exception 'admin required'; end if;
+  update public.user_profiles set panels = p_panels, updated_at = now() where user_id = p_user_id;
+end $$;
+
 create or replace function public.admin_update_filial_info(
   p_filial_id uuid,
   p_kind text,

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -55,11 +55,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const { data: allowedPanelsData } = await supabase.rpc('get_my_allowed_panels');
 
         if (profileData || allowedPanelsData) {
+          const branchPanels = Array.isArray(allowedPanelsData) ? allowedPanelsData : [];
+          const userPanels = Array.isArray(profileData?.panels) ? profileData.panels : [];
+          const mergedPanels = Array.from(new Set([...branchPanels, ...userPanels]));
           setProfile(prev => ({
             role: userRole,
             user_id: profileData?.user_id || currentUser.id,
             full_name: profileData?.full_name || prev?.full_name || currentUser.email,
-            panels: (allowedPanelsData as string[] | null) ?? profileData?.panels ?? prev?.panels ?? [],
+            panels: mergedPanels,
             is_active: (profileData?.is_active ?? prev?.is_active ?? true) as boolean,
             filial_id: (profileData?.filial_id ?? prev?.filial_id ?? null) as string | null,
           }));
@@ -100,11 +103,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           const { data: allowedPanelsData } = await supabase.rpc('get_my_allowed_panels');
 
           if (profileData || allowedPanelsData) {
+            const branchPanels = Array.isArray(allowedPanelsData) ? allowedPanelsData : [];
+            const userPanels = Array.isArray(profileData?.panels) ? profileData.panels : [];
+            const mergedPanels = Array.from(new Set([...branchPanels, ...userPanels]));
             setProfile(prev => ({
               role: userRole,
               user_id: profileData?.user_id || newUser.id,
               full_name: profileData?.full_name || prev?.full_name || newUser.email,
-              panels: (allowedPanelsData as string[] | null) ?? profileData?.panels ?? prev?.panels ?? [],
+              panels: mergedPanels,
               is_active: (profileData?.is_active ?? prev?.is_active ?? true) as boolean,
               filial_id: (profileData?.filial_id ?? prev?.filial_id ?? null) as string | null,
             }));


### PR DESCRIPTION
## Summary
- allow editing of user-specific panel access in admin Users page
- introduce `admin_set_user_panels` RPC for persisting panel selections
- merge filial and user panel permissions in AuthProvider

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a02eed6954832aadc1ac5150f44249