### PR TITLE
feat(login): add email verification reminder

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,10 +7,11 @@ import { QuickLoginWidget } from "@/components/QuickLoginWidget";
 
 export default function LoginPage() {
   const [params] = useSearchParams();
-  const scope = params.get('scope');
+  const scope = params.get("scope");
+  const msg = params.get("msg");
   const label = labelFromScope(scope);
   const redirectPath = pathFromScope(scope);
-  const title = label ? `Entrar — ${label}` : 'Entrar na plataforma';
+  const title = label ? `Entrar — ${label}` : "Entrar na plataforma";
 
   useEffect(() => {
     document.title = `${title} | BlockURB`;
@@ -26,6 +27,11 @@ export default function LoginPage() {
   return (
     <AuthLayout>
       <div className="space-y-6">
+        {msg === "check-email" && (
+          <div className="rounded-md border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">
+            Verifique seu e-mail para confirmar o cadastro.
+          </div>
+        )}
         <LoginForm title={title} subtitle={label ? `Área: ${label}` : undefined} scope={scope} redirectPath={redirectPath} />
         
         {/* Widget de Login Rápido na página de login sem scope específico */}


### PR DESCRIPTION
## Summary
- show notice to check email for verification when `msg=check-email`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 99 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0441cf8d4832a9c34b0b458c80890