### PR TITLE
feat: set default signup scope

### DIFF
--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -6,7 +6,7 @@ import { labelFromScope } from "@/config/authConfig";
 
 export default function SignupPage() {
   const [params] = useSearchParams();
-  const scope = params.get('scope');
+  const scope = params.get('scope') ?? 'investidor';
   const label = labelFromScope(scope);
   const title = label ? `Criar conta — ${label}` : 'Criar conta';
 


### PR DESCRIPTION
## Summary
- default scope to `investidor` when reading URL params

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a046a58e18832aa34668ec03cd8dd6