### PR TITLE
feat: capture filial reference during signup

### DIFF
--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -7,6 +7,7 @@ import { labelFromScope } from "@/config/authConfig";
 export default function SignupPage() {
   const [params] = useSearchParams();
   const scope = params.get('scope');
+  const filialId = params.get('filialId') ?? undefined;
   const label = labelFromScope(scope);
   const title = label ? `Criar conta — ${label}` : 'Criar conta';
 
@@ -23,7 +24,7 @@ export default function SignupPage() {
 
   return (
     <AuthLayout>
-      <SignupForm title={title} scope={scope} />
+      <SignupForm title={title} scope={scope} filialId={filialId} />
     </AuthLayout>
   );
 }


### PR DESCRIPTION
## Summary
- accept filialId in SignupForm and upsert user profile after sign-up
- forward scope and filialId from Signup page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 99 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a046d4b4b0832a9d296695149e7648