### PR TITLE
fix: replace console.log in MapView

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -78,7 +78,7 @@ export function MapView({
           setLotes(data);
           renderLotes(data);
         } else {
-          console.log('ℹ️ Nenhum lote encontrado para este empreendimento');
+          console.warn('⚠️ Nenhum lote encontrado para este empreendimento');
         }
       } catch (error) {
         console.error('Erro ao carregar lotes:', error);


### PR DESCRIPTION
## Summary
- replace console.log with console.warn when no lots are found in MapView

## Testing
- `npm run lint` *(fails: 99 problems (71 errors, 28 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a04a144ea8832ab079afae0308e389