### PR TITLE
feat: add weekly sales chart

### DIFF
--- a/src/components/app/WeeklySalesChart.tsx
+++ b/src/components/app/WeeklySalesChart.tsx
@@ -1,0 +1,32 @@
+import { salesByWeek } from "@/mocks/charts";
+import { Button } from "@/components/ui/button";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
+
+export function WeeklySalesChart() {
+  return (
+    <div className="rounded-[14px] border border-border bg-secondary/60 p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold">Vendas por semana</h3>
+        <Button variant="outline" size="sm">Exportar</Button>
+      </div>
+      <ChartContainer
+        className="mt-4 h-56"
+        config={{
+          value: {
+            label: "Vendas",
+            color: "hsl(var(--primary))",
+          },
+        }}
+      >
+        <LineChart data={salesByWeek}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="week" />
+          <YAxis allowDecimals={false} />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Line type="monotone" dataKey="value" stroke="var(--color-value)" strokeWidth={2} />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  );
+}

--- a/src/mocks/charts.ts
+++ b/src/mocks/charts.ts
@@ -4,4 +4,3 @@ export const salesByWeek = [
   { week: 'W3', value: 15 },
   { week: 'W4', value: 22 },
 ];
-// TODO: ligar em lib de gráfico futuramente

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -3,10 +3,10 @@ import { Protected } from "@/components/Protected";
 import { KPIStat } from "@/components/app/KPIStat";
 import { FiltersBar } from "@/components/app/FiltersBar";
 import { DataTable } from "@/components/app/DataTable";
-import { ChartPlaceholder } from "@/components/app/ChartPlaceholder";
+import { WeeklySalesChart } from "@/components/app/WeeklySalesChart";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Building2, Users, FileText, Target } from "lucide-react";
+import { Building2, FileText, Target } from "lucide-react";
 
 const columns = [
   { key: 'nome', header: 'Nome' },
@@ -67,7 +67,7 @@ export default function AdminDashboard() {
             <DataTable columns={columns} rows={rows} pageSize={5} />
           </div>
           <div>
-            <ChartPlaceholder title="Vendas por semana" />
+            <WeeklySalesChart />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- integrate weekly sales chart using Recharts
- remove obsolete TODO comment in mock data
- display chart on admin dashboard

## Testing
- `npm run lint` *(fails: Unexpected any and require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a04a166d50832a812dba51f667894d