### PR TITLE
Ensure secure signup defaults and role assignment

### DIFF
--- a/USUARIOS_E_CREDENCIAIS.md
+++ b/USUARIOS_E_CREDENCIAIS.md
@@ -77,10 +77,21 @@
 **Funcionalidades:** Carteira e suporte
 
 ### Terrenista
-**Email:** `terrenista@blockurb.com`  
-**Senha:** `Terra2024!`  
-**Painel:** `/terrenista`  
+**Email:** `terrenista@blockurb.com`
+**Senha:** `Terra2024!`
+**Painel:** `/terrenista`
 **Funcionalidades:** Status e pagamentos
+
+## 🔐 Criação de Contas Privilegiadas
+
+- O formulário de cadastro cria **sempre** usuários com o cargo `investidor`.
+- Para atribuir cargos elevados (ex.: `admin`, `superadmin`), um **superadmin** deve utilizar a função protegida `admin_update_user_role`.
+- Recomendação:
+  1. Solicitar que o novo usuário realize o cadastro comum.
+  2. Confirmar o e-mail do usuário.
+  3. Executar, autenticado como superadmin, a chamada RPC `admin_update_user_role` informando `p_user_id` e o cargo desejado.
+
+Assim evitamos que links de cadastro definam privilégios de forma insegura.
 
 ## 🗺️ Funcionalidades Especiais
 

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -8,10 +8,9 @@ import { useNavigate } from "react-router-dom";
 
 export interface SignupFormProps {
   title: string;
-  scope?: string | null;
 }
 
-export function SignupForm({ title, scope }: SignupFormProps) {
+export function SignupForm({ title }: SignupFormProps) {
   const { register, handleSubmit } = useForm<{ name: string; email: string; password: string; confirm: string; terms: boolean }>();
   const [agreeError, setAgreeError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -26,12 +25,9 @@ export function SignupForm({ title, scope }: SignupFormProps) {
     const { error } = await supabase.auth.signUp({ email: data.email, password: data.password, options: { data: { full_name: data.name } } });
     if (error) { setError(error.message || 'Falha ao criar conta'); return; }
     const qs = new URLSearchParams();
-    if (scope) qs.set('scope', scope);
     qs.set('msg', 'check-email');
     navigate(`/login?${qs.toString()}`);
   });
-
-  const preserve = scope ? `?scope=${encodeURIComponent(scope)}` : '';
 
   return (
     <form onSubmit={onSubmit} className="space-y-6">
@@ -70,7 +66,7 @@ export function SignupForm({ title, scope }: SignupFormProps) {
 
       <div className="flex items-center justify-between text-sm">
         <span className="text-muted-foreground">Já tem conta?</span>
-        <a href={`/login${preserve}`} className="story-link">Entrar</a>
+        <a href="/login" className="story-link">Entrar</a>
       </div>
 
       <div role="status" aria-live="polite" className="sr-only" />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,14 +1,9 @@
 import { useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
 import AuthLayout from "@/components/auth/AuthLayout";
 import { SignupForm } from "@/components/auth/SignupForm";
-import { labelFromScope } from "@/config/authConfig";
 
 export default function SignupPage() {
-  const [params] = useSearchParams();
-  const scope = params.get('scope');
-  const label = labelFromScope(scope);
-  const title = label ? `Criar conta — ${label}` : 'Criar conta';
+  const title = 'Criar conta';
 
   useEffect(() => {
     document.title = `${title} | BlockURB`;
@@ -23,7 +18,7 @@ export default function SignupPage() {
 
   return (
     <AuthLayout>
-      <SignupForm title={title} scope={scope} />
+      <SignupForm title={title} />
     </AuthLayout>
   );
 }

--- a/supabase/role-security.sql
+++ b/supabase/role-security.sql
@@ -1,0 +1,56 @@
+-- Define default role 'investidor' for new users and restrict role assignments
+
+-- Trigger to create a profile and assign default role after user signup
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.user_profiles (user_id, email, full_name, role, is_active)
+  values (new.id, new.email, coalesce(new.raw_user_meta_data->>'full_name', new.email), 'investidor', true);
+  update auth.users
+     set raw_app_meta_data = jsonb_set(coalesce(raw_app_meta_data, '{}'::jsonb), '{role}', to_jsonb('investidor'), true)
+   where id = new.id;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- Helper functions to detect superadmin
+create or replace function public.is_superadmin(uid uuid)
+returns boolean language sql stable as $$
+  select exists (
+    select 1 from public.user_profiles up
+    where up.user_id = uid and up.is_active and lower(up.role) = 'superadmin'
+  );
+$$;
+
+create or replace function public.is_superadmin()
+returns boolean language sql stable as $$
+  select public.is_superadmin(auth.uid());
+$$;
+
+-- Only superadmin may assign roles other than the default 'investidor'
+create or replace function public.admin_update_user_role(p_user_id uuid, p_role text)
+returns void language plpgsql as $$
+begin
+  if lower(p_role) <> 'investidor' then
+    if not public.is_superadmin(auth.uid()) then
+      raise exception 'superadmin required';
+    end if;
+  else
+    if not public.is_admin(auth.uid()) then
+      raise exception 'admin required';
+    end if;
+  end if;
+  update public.user_profiles
+    set role = p_role,
+        updated_at = now()
+    where user_id = p_user_id;
+end;
+$$;


### PR DESCRIPTION
## Summary
- Remove query-string scope handling from signup flow
- Default new accounts to investor and restrict role elevation to superadmins
- Document safe procedure for creating privileged accounts

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a04d83851c832aa73cb6387e618f80