### PR TITLE
Ensure adminfilial panel access by default

### DIFF
--- a/supabase-complete-setup.js
+++ b/supabase-complete-setup.js
@@ -212,19 +212,29 @@ async function completeSupabaseSetup() {
       console.log(`❌ Login admin falhou: ${loginError.message}`);
     } else {
       console.log('✅ Login admin funcionando');
-      
+
+      // Verificar painéis permitidos
+      const { data: panels, error: panelsError } = await supabase.rpc('get_my_allowed_panels');
+      if (panelsError) {
+        console.log(`⚠️ get_my_allowed_panels: ${panelsError.message}`);
+      } else {
+        const list = panels || [];
+        console.log(`${list.includes('adminfilial') ? '✅' : '❌'} Admin possui painel adminfilial`);
+        console.log(`${list.includes('superadmin') ? '⚠️' : '✅'} Admin não possui painel superadmin`);
+      }
+
       // Testar acesso a dados com usuário autenticado
       const { data: userEmps, error: userEmpsError } = await supabase
         .from('empreendimentos')
         .select('*')
         .limit(5);
-      
+
       if (userEmpsError) {
         console.log(`⚠️ Acesso a empreendimentos como admin: ${userEmpsError.message}`);
       } else {
         console.log(`✅ Admin pode acessar ${userEmps.length} empreendimentos`);
       }
-      
+
       // Logout
       await supabase.auth.signOut();
       console.log('✅ Logout realizado');

--- a/supabase/functions/create-admin-filial/index.ts
+++ b/supabase/functions/create-admin-filial/index.ts
@@ -97,6 +97,7 @@ serve(async (req) => {
       full_name: full_name || email,
       role: "adminfilial",
       filial_id: filialIdToUse,
+      panels: ['adminfilial'],
       is_active: true,
     });
     if (upErr) return new Response(JSON.stringify({ error: upErr.message }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });


### PR DESCRIPTION
## Summary
- Include adminfilial panel for branch admins in user profile creation
- Guarantee RPC `get_my_allowed_panels` always returns `adminfilial` for branch admins
- Extend setup script to verify branch admins receive the correct panel without superadmin rights

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 71 errors, 28 warnings)*
- `node supabase-complete-setup.js` *(fails: ENETUNREACH network error)*

------
https://chatgpt.com/codex/tasks/task_e_68a04fbfc384832ab574e9067ddec18a