### PR TITLE
fix: use lazy route for debug connection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,14 +178,14 @@ const App = () => (
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
             
-            {/* Debug routes */}
-            <Route path="/debug/connection" element={<div style={{all:'initial'}}><div id="debug-connection-root"></div></div>} />
-            
-            {/* Load debug component dynamically */}
-            <Route path="/debug/connection" lazy={async () => {
-              const Component = (await import("./app/debug/connection/page")).default;
-              return { Component };
-            }} />
+            {/* Debug route */}
+            <Route
+              path="/debug/connection"
+              lazy={async () => {
+                const Component = (await import("./app/debug/connection/page")).default;
+                return { Component };
+              }}
+            />
             
             {/* Rota Catch-all no final */}
             <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
## Summary
- remove duplicate `/debug/connection` route
- load the debug connection page through React Router lazy import

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=anon npm run build`
- `curl -i http://localhost:4173/debug/connection | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a062861468832a8b7e8fe1bb4b2907