### PR TITLE
Add admin_list_users function

### DIFF
--- a/app.final.sql
+++ b/app.final.sql
@@ -609,6 +609,19 @@ begin
    where id = p_filial_id;
 end $$;
 
+create or replace function public.admin_list_users()
+returns setof auth.users
+language plpgsql
+security definer
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'admin required';
+  end if;
+  return query select * from auth.users;
+end $$;
+grant execute on function public.admin_list_users() to authenticated;
+
 create or replace function public.process_geojson_lotes(
   p_empreendimento_id uuid,
   p_geojson jsonb,

--- a/supabase/migrations/20250816105500_admin_list_users.sql
+++ b/supabase/migrations/20250816105500_admin_list_users.sql
@@ -1,0 +1,14 @@
+-- Add admin_list_users function
+create or replace function public.admin_list_users()
+returns setof auth.users
+language plpgsql
+security definer
+as $$
+begin
+  if not public.is_admin(auth.uid()) then
+    raise exception 'admin required';
+  end if;
+  return query select * from auth.users;
+end $$;
+
+grant execute on function public.admin_list_users() to authenticated;


### PR DESCRIPTION
## Summary
- add `admin_list_users` with SECURITY DEFINER returning `auth.users`
- grant execute on `admin_list_users` to `authenticated`
- create matching Supabase migration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 99 problems (71 errors, 28 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68a062f8a91c832a9b8d899268a0afa0