### PR TITLE
feat: add audit logging and global reports

### DIFF
--- a/audit_logs.sql
+++ b/audit_logs.sql
@@ -1,0 +1,79 @@
+-- ================================================================
+-- Audit logs and KPI aggregation
+-- ================================================================
+
+-- Extensions
+create extension if not exists "pgcrypto";
+create extension if not exists "cron";
+
+-- Table to store audit events
+create table if not exists public.audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  filial_id uuid references public.filiais(id) on delete set null,
+  action text not null,
+  table_name text,
+  record_id uuid,
+  metadata jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Enable RLS and policies
+alter table public.audit_logs enable row level security;
+
+create policy "allow_insert_auth" on public.audit_logs
+  for insert
+  with check (auth.role() = 'authenticated');
+
+create policy "superadmin_select" on public.audit_logs
+  for select using (
+    exists (
+      select 1 from public.user_profiles up
+      where up.user_id = auth.uid() and up.role = 'superadmin'
+    )
+  );
+
+-- Aggregated KPIs table
+create table if not exists public.kpi_aggregates (
+  filial_id uuid references public.filiais(id) on delete cascade,
+  total_logins bigint default 0,
+  total_criacoes bigint default 0,
+  total_atualizacoes bigint default 0,
+  calculated_at timestamptz not null default now()
+);
+
+-- Function to refresh KPI aggregates
+create or replace function public.refresh_kpi_aggregates()
+returns void language plpgsql security definer as $$
+begin
+  truncate table public.kpi_aggregates;
+  insert into public.kpi_aggregates (filial_id, total_logins, total_criacoes, total_atualizacoes)
+  select
+    filial_id,
+    count(*) filter (where action = 'login') as total_logins,
+    count(*) filter (where action = 'create') as total_criacoes,
+    count(*) filter (where action = 'update') as total_atualizacoes
+  from public.audit_logs
+  group by filial_id;
+end;
+$$;
+
+-- RPC to fetch aggregates
+create or replace function public.get_global_kpis()
+returns table (
+  filial_id uuid,
+  total_logins bigint,
+  total_criacoes bigint,
+  total_atualizacoes bigint,
+  calculated_at timestamptz
+) language sql security definer as $$
+  select filial_id, total_logins, total_criacoes, total_atualizacoes, calculated_at
+  from public.kpi_aggregates;
+$$;
+
+-- Schedule periodic refresh every hour
+select cron.schedule(
+  'refresh_kpi_aggregates',
+  '0 * * * *',
+  $$select public.refresh_kpi_aggregates()$$
+);

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Eye, EyeOff, Crown, User } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logAudit } from "@/lib/utils";
 
 export interface LoginFormProps {
   title: string;
@@ -38,6 +39,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
+        await logAudit("login", { table_name: "auth", record_id: res.session.user.id })
         navigate(redirectPath || "/admin");
       }
     } catch (err) {
@@ -63,6 +65,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
+        await logAudit("login", { table_name: "auth", record_id: res.session.user.id })
         navigate(redirectPath || "/admin");
       }
     } catch (err) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,31 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { supabase } from "./dataClient"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export type AuditAction = "login" | "create" | "update"
+
+export async function logAudit(
+  action: AuditAction,
+  details: { table_name?: string; record_id?: string; metadata?: Record<string, any>; filial_id?: string } = {}
+) {
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    await supabase.from("audit_logs").insert({
+      user_id: user?.id ?? null,
+      filial_id: details.filial_id ?? null,
+      action,
+      table_name: details.table_name ?? null,
+      record_id: details.record_id ?? null,
+      metadata: details.metadata ?? null,
+    })
+  } catch (err) {
+    console.error("audit log failed", err)
+  }
 }

--- a/src/pages/admin/RelatoriosGlobais.tsx
+++ b/src/pages/admin/RelatoriosGlobais.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react"
+import { supabase } from "@/lib/dataClient"
+import { Protected } from "@/components/Protected"
+import { AppShell } from "@/components/shell/AppShell"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+interface AuditLog {
+  id: string
+  action: string
+  metadata: any
+  created_at: string
+}
+
+interface KPI {
+  filial_id: string | null
+  total_logins: number
+  total_criacoes: number
+  total_atualizacoes: number
+  calculated_at: string
+}
+
+export default function RelatoriosGlobais() {
+  const [logs, setLogs] = useState<AuditLog[]>([])
+  const [kpis, setKpis] = useState<KPI[]>([])
+
+  useEffect(() => {
+    fetchAll()
+  }, [])
+
+  const fetchAll = async () => {
+    const { data: logData } = await supabase
+      .from("audit_logs")
+      .select("id, action, metadata, created_at")
+      .order("created_at", { ascending: false })
+      .limit(50)
+    setLogs(logData || [])
+
+    const { data: kpiData } = await supabase.rpc("get_global_kpis")
+    setKpis(kpiData || [])
+  }
+
+  return (
+    <Protected>
+      <AppShell breadcrumbs={[{ label: "Admin", href: "/admin" }, { label: "Relatórios Globais" }]}>
+        <div className="grid gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {kpis.map((k) => (
+              <Card key={k.filial_id || "global"}>
+                <CardHeader>
+                  <CardTitle>{k.filial_id || "Global"}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-1 text-sm">
+                  <div>Logins: {k.total_logins}</div>
+                  <div>Criações: {k.total_criacoes}</div>
+                  <div>Alterações: {k.total_atualizacoes}</div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Últimos eventos</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Ação</TableHead>
+                    <TableHead>Detalhes</TableHead>
+                    <TableHead>Quando</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {logs.map((l) => (
+                    <TableRow key={l.id}>
+                      <TableCell>{l.action}</TableCell>
+                      <TableCell>
+                        <pre className="whitespace-pre-wrap text-xs">
+                          {JSON.stringify(l.metadata)}
+                        </pre>
+                      </TableCell>
+                      <TableCell>
+                        {new Date(l.created_at).toLocaleString()}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </div>
+      </AppShell>
+    </Protected>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `audit_logs` table and KPI aggregation function with cron schedule
- implement `logAudit` helper and integrate login logging
- create global reports page and surface KPIs on admin dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a063cad178832aa66b058561c04bf6