### PR TITLE
feat: add filial provisioning

### DIFF
--- a/app.final.sql
+++ b/app.final.sql
@@ -29,6 +29,7 @@ create table if not exists public.filiais (
   billing_status text null,
   domain text null,
   is_active boolean not null default true,
+  status text not null default 'provisionando',
   created_at timestamptz not null default now()
 );
 alter table public.filiais add column if not exists kind text;
@@ -38,6 +39,7 @@ alter table public.filiais add column if not exists billing_plan text;
 alter table public.filiais add column if not exists billing_status text;
 alter table public.filiais add column if not exists domain text;
 alter table public.filiais add column if not exists is_active boolean not null default true;
+alter table public.filiais add column if not exists status text not null default 'provisionando';
 alter table public.filiais add column if not exists created_at timestamptz not null default now();
 create index if not exists idx_filiais_active on public.filiais(is_active);
 

--- a/src/pages/admin/Filiais.tsx
+++ b/src/pages/admin/Filiais.tsx
@@ -23,19 +23,13 @@ interface Filial {
   billing_status?: string | null;
   domain?: string | null;
   is_active?: boolean;
+  status?: string;
 }
 
 export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" }) {
   const [filiais, setFiliais] = useState<Filial[]>([]);
-  const [novaFilialNome, setNovaFilialNome] = useState("");
   const [loading, setLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [novaKind, setNovaKind] = useState<string>('interna');
-  const [novaOwnerName, setNovaOwnerName] = useState("");
-  const [novaOwnerEmail, setNovaOwnerEmail] = useState("");
-  const [novaPlan, setNovaPlan] = useState("");
-  const [novaBilling, setNovaBilling] = useState("");
-  const [novaDomain, setNovaDomain] = useState("");
   const [editing, setEditing] = useState<Record<string, Partial<Filial>>>({});
   // Admins de Filial (unificado)
   const [admins, setAdmins] = useState<any[]>([]);
@@ -62,7 +56,7 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
     setLoading(true);
     const { data, error } = await supabase
       .from('filiais')
-      .select('id, nome, created_at, kind, owner_name, owner_email, billing_plan, billing_status, domain, is_active')
+      .select('id, nome, created_at, kind, owner_name, owner_email, billing_plan, billing_status, domain, is_active, status')
       .order('nome', { ascending: true });
 
     if (error) {
@@ -73,38 +67,18 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
     setLoading(false);
   };
 
-  const handleAddFilial = async () => {
-    if (!novaFilialNome.trim()) {
-      toast.warning("O nome da filial não pode estar vazio.");
+  const provisionFilial = async (payload: any, success: string) => {
+    setIsSubmitting(true);
+    const { error } = await supabase.functions.invoke('provision-filial', {
+      body: payload,
+    });
+    setIsSubmitting(false);
+    if (error) {
+      toast.error(error.message);
       return;
     }
-    setIsSubmitting(true);
-    const { error } = await supabase
-      .from('filiais')
-      .insert([{ 
-        nome: novaFilialNome.trim(),
-        kind: novaKind,
-        owner_name: novaOwnerName || null,
-        owner_email: novaOwnerEmail || null,
-        billing_plan: novaPlan || null,
-        billing_status: novaBilling || null,
-        domain: novaDomain || null,
-      }]);
-
-    if (error) {
-      toast.error(`Erro ao adicionar filial: ${error.message}`);
-    } else {
-      toast.success(`Filial "${novaFilialNome.trim()}" adicionada com sucesso!`);
-      setNovaFilialNome("");
-      setNovaKind('interna');
-      setNovaOwnerName("");
-      setNovaOwnerEmail("");
-      setNovaPlan("");
-      setNovaBilling("");
-      setNovaDomain("");
-      fetchFiliais(); // Re-fetch the list
-    }
-    setIsSubmitting(false);
+    toast.success(success);
+    fetchFiliais();
   };
 
   const setEdit = (id: string, field: keyof Filial, value: any) => {
@@ -253,14 +227,9 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
                   <Button variant="ghost" onClick={() => setOpenInternal(false)}>Cancelar</Button>
                   <Button onClick={async () => {
                     if (!formInternal.nome.trim()) { toast.error('Informe o nome'); return; }
-                    setIsSubmitting(true);
-                    const { error } = await supabase.from('filiais').insert([{ nome: formInternal.nome.trim(), kind: 'interna' }]);
-                    setIsSubmitting(false);
-                    if (error) { toast.error(error.message); return; }
-                    toast.success('Filial interna criada');
+                    await provisionFilial({ nome: formInternal.nome.trim(), kind: 'interna' }, 'Filial interna criada');
                     setFormInternal({ nome: '' });
                     setOpenInternal(false);
-                    fetchFiliais();
                   }}>{isSubmitting ? 'Salvando...' : 'Salvar'}</Button>
                 </DialogFooter>
               </DialogContent>
@@ -307,8 +276,7 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
                   <Button variant="ghost" onClick={() => setOpenSaas(false)}>Cancelar</Button>
                   <Button onClick={async () => {
                     if (!formSaas.nome.trim()) { toast.error('Informe o nome'); return; }
-                    setIsSubmitting(true);
-                    const { error } = await supabase.from('filiais').insert([{ 
+                    await provisionFilial({
                       nome: formSaas.nome.trim(),
                       kind: 'saas',
                       owner_name: formSaas.owner_name || null,
@@ -316,13 +284,9 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
                       billing_plan: formSaas.billing_plan || null,
                       billing_status: formSaas.billing_status || null,
                       domain: formSaas.domain || null,
-                    }]);
-                    setIsSubmitting(false);
-                    if (error) { toast.error(error.message); return; }
-                    toast.success('Cliente SaaS criado');
+                    }, 'Cliente SaaS criado');
                     setFormSaas({ nome: '', owner_name: '', owner_email: '', billing_plan: '', billing_status: '', domain: '' });
                     setOpenSaas(false);
-                    fetchFiliais();
                   }}>{isSubmitting ? 'Salvando...' : 'Salvar'}</Button>
                 </DialogFooter>
               </DialogContent>

--- a/supabase/functions/provision-filial/index.ts
+++ b/supabase/functions/provision-filial/index.ts
@@ -1,0 +1,154 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") || "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization") || "";
+    if (!authHeader.startsWith("Bearer ")) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const userClient = createClient(SUPABASE_URL, ANON_KEY, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const adminClient = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    const {
+      data: { user },
+      error: getUserErr,
+    } = await userClient.auth.getUser();
+    if (getUserErr || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+      const { data: profile } = await userClient
+        .from("user_profiles")
+        .select("role")
+        .eq("user_id", user.id)
+        .single();
+      const appRole = (user as { app_metadata?: { role?: string } })
+        .app_metadata?.role;
+      const isSuperadmin =
+        profile?.role === "superadmin" || appRole === "superadmin";
+    if (!isSuperadmin) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const {
+      nome,
+      kind = "interna",
+      owner_name,
+      owner_email,
+      billing_plan,
+      billing_status,
+      domain,
+    } = await req.json();
+
+    if (!nome) {
+      return new Response(JSON.stringify({ error: "Nome obrigatório" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: filial, error: filialErr } = await adminClient
+      .from("filiais")
+      .insert({
+        nome,
+        kind,
+        owner_name,
+        owner_email,
+        billing_plan,
+        billing_status,
+        domain,
+        status: "provisionando",
+      })
+      .select("id")
+      .single();
+
+    if (filialErr || !filial) {
+      return new Response(
+        JSON.stringify({ error: filialErr?.message || "Falha ao criar filial" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const filialId = filial.id as string;
+
+    // Registros auxiliares
+    if (billing_plan || billing_status) {
+      await adminClient
+        .from("billing")
+        .insert({ filial_id: filialId, plan: billing_plan, status: billing_status })
+        .catch(() => {});
+    }
+    if (domain) {
+      await adminClient
+        .from("domains")
+        .insert({ filial_id: filialId, domain })
+        .catch(() => {});
+    }
+
+    // Disparar jobs assíncronos
+    const storageWebhook = Deno.env.get("STORAGE_PROVISION_WEBHOOK");
+    const policiesWebhook = Deno.env.get("POLICIES_PROVISION_WEBHOOK");
+    if (storageWebhook) {
+      fetch(storageWebhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filial_id: filialId }),
+      }).catch(() => {});
+    }
+    if (policiesWebhook) {
+      fetch(policiesWebhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filial_id: filialId }),
+      }).catch(() => {});
+    }
+
+    return new Response(JSON.stringify({ id: filialId }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e?.message || e) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add edge function to provision new filial and related records
- integrate provisioning call in Filiais page
- track filial provisioning status in schema

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a063cbf004832ab0c4d259ccffc38d