### PR TITLE
refactor: centralized route config with filial context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,45 +2,12 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { ProgressBar } from "@/components/ui/ProgressBar";
-import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
-import Whitepaper from "./pages/Whitepaper";
-import Acesso from "./pages/Acesso";
-import Login from "./pages/Login";
-import Signup from "./pages/Signup";
-import Reset from "./pages/Reset";
-import LoginSuperAdmin from "./pages/login/SuperAdmin";
-import LoginAdmin from "./pages/login/Admin";
-import LoginImobiliaria from "./pages/login/Imobiliaria";
-import LoginCorretor from "./pages/login/Corretor";
-import LoginJuridico from "./pages/login/Juridico";
-import LoginUrbanismo from "./pages/login/Urbanismo";
-import LoginContabilidade from "./pages/login/Contabilidade";
-import LoginMarketing from "./pages/login/Marketing";
-import LoginComercial from "./pages/login/Comercial";
-import LoginObras from "./pages/login/Obras";
-import LoginInvestidor from "./pages/login/Investidor";
-import LoginTerrenista from "./pages/login/Terrenista";
 import { AuthProvider } from "@/providers/AuthProvider";
-import { PanelHomePage, PanelSectionPage } from "@/components/panels/PanelPages";
-import EmpreendimentoNovo from "./pages/admin/EmpreendimentoNovo";
-import AdminMapa from "./pages/admin/Mapa";
-import MapaInterativo from "./pages/admin/MapaInterativo";
-import LotesVendas from "./pages/admin/LotesVendas";
-import AprovacaoEmpreendimentos from "./pages/admin/AprovacaoEmpreendimentos";
-import Logout from "./pages/Logout";
-import LotesPage from "./pages/admin/Lotes";
-import FiliaisPage from "./pages/admin/Filiais";
-import FiliaisInternasPage from "./pages/admin/FiliaisInternas";
-import ClientesSaasPage from "./pages/admin/ClientesSaas";
-import FiliaisAccessPage from "./pages/admin/FiliaisAccess";
-import UsuariosPage from "./pages/admin/Usuarios";
-import AdminsFiliaisPage from "./pages/admin/AdminsFiliais";
-import AcessoNegado from "./pages/AcessoNegado";
+import { publicRoutes, panelRoutes } from "@/config/routes";
 import { Protected } from "@/components/Protected";
-import MapaSuperAdmin from "./pages/admin/MapaSuperAdmin";
 
 const queryClient = new QueryClient();
 
@@ -53,141 +20,26 @@ const App = () => (
       <BrowserRouter>
         <AuthProvider>
           <Routes>
-            {/* Rotas Públicas */}
-            <Route path="/" element={<Index />} />
-            <Route path="/whitepaper" element={<Whitepaper />} />
-            <Route path="/acesso" element={<Acesso />} />
-
-            {/* Auth base routes */}
-            <Route path="/login" element={<Login />} />
-            <Route path="/signup" element={<Signup />} />
-            <Route path="/reset" element={<Reset />} />
-
-            {/* Auth scoped routes */}
-            <Route path="/login/super-admin" element={<LoginSuperAdmin />} />
-            <Route path="/login/admin" element={<LoginAdmin />} />
-            <Route path="/login/imobiliaria" element={<LoginImobiliaria />} />
-            <Route path="/login/corretor" element={<LoginCorretor />} />
-            <Route path="/login/juridico" element={<LoginJuridico />} />
-            <Route path="/login/urbanismo" element={<LoginUrbanismo />} />
-            <Route path="/login/contabilidade" element={<LoginContabilidade />} />
-            <Route path="/login/marketing" element={<LoginMarketing />} />
-            <Route path="/login/comercial" element={<LoginComercial />} />
-            <Route path="/login/obras" element={<LoginObras />} />
-            <Route path="/login/investidor" element={<LoginInvestidor />} />
-            <Route path="/login/terrenista" element={<LoginTerrenista />} />
-            <Route path="/logout" element={<Logout />} />
-            <Route path="/acesso-negado" element={<AcessoNegado />} />
-
-            {/* Panels - ROTAS PROTEGIDAS */}
-            {/* Super Admin */}
-            <Route path="/super-admin" element={<Protected allowedRoles={['superadmin']}><PanelHomePage menuKey="superadmin" title="Super Admin" /></Protected>} />
-            <Route path="/super-admin/admins-filiais" element={<Protected allowedRoles={['superadmin']}><AdminsFiliaisPage /></Protected>} />
-            <Route path="/super-admin/filiais-internas" element={<Protected allowedRoles={['superadmin']}><FiliaisInternasPage /></Protected>} />
-<Route path="/super-admin/clientes-saas" element={<Protected allowedRoles={['superadmin']}><ClientesSaasPage /></Protected>} />
-            <Route path="/super-admin/filiais-acessos" element={<Protected allowedRoles={['superadmin']}><FiliaisAccessPage /></Protected>} />
-            <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
-            <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Relatórios" /></Protected>} />
-            <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Configurações" /></Protected>} />
-            <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
-            <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />
-
-            {/* Admin Filial - Rotas padronizadas em /admin-filial */}
-            <Route path="/admin-filial" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelHomePage menuKey="adminfilial" title="Admin Filial" /></Protected>} />
-            <Route path="/admin-filial/relatorios" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Relatórios" /></Protected>} />
-            <Route path="/admin-filial/config" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Configurações" /></Protected>} />
-            <Route path="/admin-filial/equipe" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Equipe" /></Protected>} />
-            <Route path="/admin-filial/empreendimentos" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Empreendimentos" /></Protected>} />
-            <Route path="/admin-filial/empreendimentos/novo" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><EmpreendimentoNovo /></Protected>} />
-            <Route path="/admin-filial/empreendimentos/editar/:id" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><EmpreendimentoNovo /></Protected>} />
-            <Route path="/admin-filial/mapa" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="urbanista"><AdminMapa /></Protected>} />
-            <Route path="/admin-filial/mapa-interativo" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="urbanista"><MapaInterativo /></Protected>} />
-            <Route path="/admin-filial/lotes" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><LotesPage /></Protected>} />
-            <Route path="/admin-filial/lotes-vendas" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="comercial"><LotesVendas /></Protected>} />
-
-            {/* Super Admin - Aprovação */}
-            <Route path="/super-admin/aprovacao" element={<Protected allowedRoles={['superadmin']}><AprovacaoEmpreendimentos /></Protected>} />
-
-            {/* Urbanista */}
-            <Route path="/urbanista" element={<Protected allowedRoles={['urbanista']}><PanelHomePage menuKey="urbanista" title="Urbanista" /></Protected>} />
-            <Route path="/urbanista/relatorios" element={<Protected allowedRoles={['urbanista']}><PanelSectionPage menuKey="urbanista" title="Urbanista" section="Relatórios" /></Protected>} />
-            <Route path="/urbanista/config" element={<Protected allowedRoles={['urbanista']}><PanelSectionPage menuKey="urbanista" title="Urbanista" section="Configurações" /></Protected>} />
-            <Route path="/urbanista/mapas" element={<Protected allowedRoles={['urbanista']}><PanelSectionPage menuKey="urbanista" title="Urbanista" section="Mapas" /></Protected>} />
-            <Route path="/urbanista/projetos" element={<Protected allowedRoles={['urbanista']}><PanelSectionPage menuKey="urbanista" title="Urbanista" section="Projetos" /></Protected>} />
-
-            {/* Jurídico */}
-            <Route path="/juridico" element={<Protected allowedRoles={['juridico']}><PanelHomePage menuKey="juridico" title="Jurídico" /></Protected>} />
-            <Route path="/juridico/relatorios" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Relatórios" /></Protected>} />
-            <Route path="/juridico/config" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Configurações" /></Protected>} />
-            <Route path="/juridico/contratos" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Contratos" /></Protected>} />
-            <Route path="/juridico/processos" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Processos" /></Protected>} />
-
-            {/* Contabilidade */}
-            <Route path="/contabilidade" element={<Protected allowedRoles={['contabilidade']}><PanelHomePage menuKey="contabilidade" title="Contabilidade" /></Protected>} />
-            <Route path="/contabilidade/relatorios" element={<Protected allowedRoles={['contabilidade']}><PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Relatórios" /></Protected>} />
-            <Route path="/contabilidade/config" element={<Protected allowedRoles={['contabilidade']}><PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Configurações" /></Protected>} />
-            <Route path="/contabilidade/financeiro" element={<Protected allowedRoles={['contabilidade']}><PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Financeiro" /></Protected>} />
-            <Route path="/contabilidade/fiscal" element={<Protected allowedRoles={['contabilidade']}><PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Fiscal" /></Protected>} />
-
-            {/* Marketing */}
-            <Route path="/marketing" element={<Protected allowedRoles={['marketing']}><PanelHomePage menuKey="marketing" title="Marketing" /></Protected>} />
-            <Route path="/marketing/relatorios" element={<Protected allowedRoles={['marketing']}><PanelSectionPage menuKey="marketing" title="Marketing" section="Relatórios" /></Protected>} />
-            <Route path="/marketing/config" element={<Protected allowedRoles={['marketing']}><PanelSectionPage menuKey="marketing" title="Marketing" section="Configurações" /></Protected>} />
-            <Route path="/marketing/campanhas" element={<Protected allowedRoles={['marketing']}><PanelSectionPage menuKey="marketing" title="Marketing" section="Campanhas" /></Protected>} />
-            <Route path="/marketing/materiais" element={<Protected allowedRoles={['marketing']}><PanelSectionPage menuKey="marketing" title="Marketing" section="Materiais" /></Protected>} />
-
-            {/* Comercial */}
-            <Route path="/comercial" element={<Protected allowedRoles={['comercial']}><PanelHomePage menuKey="comercial" title="Comercial" /></Protected>} />
-            <Route path="/comercial/relatorios" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Relatórios" /></Protected>} />
-            <Route path="/comercial/config" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Configurações" /></Protected>} />
-            <Route path="/comercial/leads" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Leads" /></Protected>} />
-            <Route path="/comercial/propostas" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Propostas" /></Protected>} />
-
-            {/* Imobiliária */}
-            <Route path="/imobiliaria" element={<Protected allowedRoles={['imobiliaria']}><PanelHomePage menuKey="imobiliaria" title="Imobiliária" /></Protected>} />
-            <Route path="/imobiliaria/relatorios" element={<Protected allowedRoles={['imobiliaria']}><PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Relatórios" /></Protected>} />
-            <Route path="/imobiliaria/config" element={<Protected allowedRoles={['imobiliaria']}><PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Configurações" /></Protected>} />
-            <Route path="/imobiliaria/corretores" element={<Protected allowedRoles={['imobiliaria']}><PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Corretores" /></Protected>} />
-            <Route path="/imobiliaria/leads" element={<Protected allowedRoles={['imobiliaria']}><PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Leads" /></Protected>} />
-
-            {/* Corretor */}
-            <Route path="/corretor" element={<Protected allowedRoles={['corretor']}><PanelHomePage menuKey="corretor" title="Corretor" /></Protected>} />
-            <Route path="/corretor/relatorios" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Relatórios" /></Protected>} />
-            <Route path="/corretor/config" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Configurações" /></Protected>} />
-            <Route path="/corretor/leads" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Leads" /></Protected>} />
-            <Route path="/corretor/vendas" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Vendas" /></Protected>} />
-
-            {/* Obras */}
-            <Route path="/obras" element={<Protected allowedRoles={['obras']}><PanelHomePage menuKey="obras" title="Obras" /></Protected>} />
-            <Route path="/obras/relatorios" element={<Protected allowedRoles={['obras']}><PanelSectionPage menuKey="obras" title="Obras" section="Relatórios" /></Protected>} />
-            <Route path="/obras/config" element={<Protected allowedRoles={['obras']}><PanelSectionPage menuKey="obras" title="Obras" section="Configurações" /></Protected>} />
-            <Route path="/obras/cronograma" element={<Protected allowedRoles={['obras']}><PanelSectionPage menuKey="obras" title="Obras" section="Cronograma" /></Protected>} />
-            <Route path="/obras/andamento" element={<Protected allowedRoles={['obras']}><PanelSectionPage menuKey="obras" title="Obras" section="Andamento" /></Protected>} />
-
-            {/* Investidor */}
-            <Route path="/investidor" element={<Protected allowedRoles={['investidor']}><PanelHomePage menuKey="investidor" title="Investidor" /></Protected>} />
-            <Route path="/investidor/relatorios" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Relatórios" /></Protected>} />
-            <Route path="/investidor/config" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Configurações" /></Protected>} />
-            <Route path="/investidor/carteira" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Carteira" /></Protected>} />
-            <Route path="/investidor/suporte" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Suporte" /></Protected>} />
-
-            {/* Terrenista */}
-            <Route path="/terrenista" element={<Protected allowedRoles={['terrenista']}><PanelHomePage menuKey="terrenista" title="Terrenista" /></Protected>} />
-            <Route path="/terrenista/relatorios" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Relatórios" /></Protected>} />
-            <Route path="/terrenista/config" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Configurações" /></Protected>} />
-            <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
-            <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
-            
-            {/* Debug routes */}
-            <Route path="/debug/connection" element={<div style={{all:'initial'}}><div id="debug-connection-root"></div></div>} />
-            
-            {/* Load debug component dynamically */}
-            <Route path="/debug/connection" lazy={async () => {
-              const Component = (await import("./app/debug/connection/page")).default;
-              return { Component };
-            }} />
-            
-            {/* Rota Catch-all no final */}
+            {publicRoutes.map(({ path, element }) => (
+              <Route key={path} path={path} element={element} />
+            ))}
+            <Route path="/:filialId/*" element={<Outlet />}>
+              {panelRoutes.map(({ path, element, roles, panelKey }) => (
+                <Route
+                  key={path}
+                  path={path}
+                  element={
+                    roles ? (
+                      <Protected allowedRoles={roles} panelKey={panelKey}>
+                        {element}
+                      </Protected>
+                    ) : (
+                      element
+                    )
+                  }
+                />
+              ))}
+            </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>
         </AuthProvider>

--- a/src/components/panels/PanelPages.tsx
+++ b/src/components/panels/PanelPages.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Building2, FileText, Target, Plus, Wrench } from "lucide-react";
 import { adminTeamColumns, adminTeamRows } from "@/mocks/tables";
 import { Link } from "react-router-dom";
+import { useAuth } from "@/providers/AuthProvider";
 
 const DevelopmentPlaceholder = ({ panelName }: { panelName: string }) => (
   <div className="rounded-[14px] border border-dashed border-border bg-secondary/60 h-[calc(100vh-200px)] grid place-items-center text-center p-4">
@@ -23,14 +24,16 @@ const DevelopmentPlaceholder = ({ panelName }: { panelName: string }) => (
 );
 
 export function PanelHomePage({ menuKey, title }: { menuKey: string; title: string }) {
+  const { profile } = useAuth();
+  const basePath = profile?.filial_id ? `/${profile.filial_id}` : '';
   // Mantém o dashboard completo para os painéis funcionais
   if (menuKey === 'superadmin' || menuKey === 'adminfilial') {
     return (
       <Protected>
-        <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}>
+        <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: basePath || '/' }, { label: title }]}> 
           <div className="flex items-center justify-between gap-3 mb-4">
             <h2 className="text-xl font-semibold">Ações rápidas</h2>
-            <Link to="/admin-filial/empreendimentos/novo">
+            <Link to={`${basePath}/admin-filial/empreendimentos/novo`}>
               <Button variant="cta" className="gap-2"><Plus className="size-4" /> Novo Empreendimento</Button>
             </Link>
           </div>
@@ -94,7 +97,7 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
   // Mostra o placeholder para todos os outros painéis
   return (
     <Protected>
-      <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}>
+      <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: basePath || '/' }, { label: title }]}> 
         <DevelopmentPlaceholder panelName={title} />
       </AppShell>
     </Protected>
@@ -102,9 +105,11 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
 }
 
 export function PanelSectionPage({ menuKey, title, section }: { menuKey: string; title: string; section: string }) {
+  const { profile } = useAuth();
+  const basePath = profile?.filial_id ? `/${profile.filial_id}` : '';
   return (
     <Protected>
-      <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }, { label: section }]}>
+      <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: basePath || '/' }, { label: title }, { label: section }]}>
         <DevelopmentPlaceholder panelName={`${title} - ${section}`} />
       </AppShell>
     </Protected>

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -64,6 +64,7 @@ export function AppSidebar({ menuKey }: { menuKey?: string }) {
   const current = location.pathname;
   const key = menuKey || inferMenuKey(current);
   const { profile } = useAuth();
+  const basePath = profile?.filial_id ? `/${profile.filial_id}` : '';
   const rawItems = NAV[key] || [];
   const isSuperAdmin = profile?.role === 'superadmin';
   const panels = Array.isArray(profile?.panels) ? (profile?.panels as string[]) : [];
@@ -89,16 +90,18 @@ export function AppSidebar({ menuKey }: { menuKey?: string }) {
           <SidebarGroupLabel>Menu</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {items.map((item) => (
+              {items.map((item) => {
+                const to = `${basePath}${item.href}`;
+                return (
                 <SidebarMenuItem key={item.href}>
-                  <SidebarMenuButton asChild isActive={current === item.href}>
-                    <NavLink to={item.href} className={({ isActive }) => cn(isActive && "text-primary font-medium") }>
+                  <SidebarMenuButton asChild isActive={current === to}>
+                    <NavLink to={to} className={({ isActive }) => cn(isActive && "text-primary font-medium") }>
                       <IconByName name={item.icon} />
                       <span>{(item as any).label ?? (item as any).title}</span>
                     </NavLink>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
-              ))}
+              );})}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/src/components/shell/Topbar.tsx
+++ b/src/components/shell/Topbar.tsx
@@ -8,14 +8,15 @@ import { Bell, Search, User as UserIcon, LogOut } from "lucide-react";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
 export function Topbar({ breadcrumbs }: { breadcrumbs?: { label: string; href?: string }[] }) {
-  const { user } = useAuth();
+  const { user, profile } = useAuth();
   const initials = (user?.email || "BU").slice(0, 2).toUpperCase();
+  const basePath = profile?.filial_id ? `/${profile.filial_id}` : '/';
 
   return (
     <header className="sticky top-0 z-40 border-b border-border bg-background/70 backdrop-blur">
       <div className="h-14 container flex items-center gap-3">
         <SidebarTrigger className="mr-2" aria-label="Alternar menu" />
-        <a href="/" className="flex items-center gap-2 font-bold tracking-tight text-lg" aria-label="Ir para a página inicial">
+        <a href={basePath} className="flex items-center gap-2 font-bold tracking-tight text-lg" aria-label="Ir para a página inicial">
           <img src="/lovable-uploads/69c3ca3e-8a72-4b83-8f97-2ffdd18f9508.png" alt="Símbolo BlockURB" className="h-6 w-6 rounded-sm" loading="lazy" decoding="async" />
           <span><span className="text-primary">Block</span>URB</span>
         </a>

--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import Index from "@/pages/Index";
+import Whitepaper from "@/pages/Whitepaper";
+import Acesso from "@/pages/Acesso";
+import Login from "@/pages/Login";
+import Signup from "@/pages/Signup";
+import Reset from "@/pages/Reset";
+import LoginSuperAdmin from "@/pages/login/SuperAdmin";
+import LoginAdmin from "@/pages/login/Admin";
+import LoginImobiliaria from "@/pages/login/Imobiliaria";
+import LoginCorretor from "@/pages/login/Corretor";
+import LoginJuridico from "@/pages/login/Juridico";
+import LoginUrbanismo from "@/pages/login/Urbanismo";
+import LoginContabilidade from "@/pages/login/Contabilidade";
+import LoginMarketing from "@/pages/login/Marketing";
+import LoginComercial from "@/pages/login/Comercial";
+import LoginObras from "@/pages/login/Obras";
+import LoginInvestidor from "@/pages/login/Investidor";
+import LoginTerrenista from "@/pages/login/Terrenista";
+import Logout from "@/pages/Logout";
+import AcessoNegado from "@/pages/AcessoNegado";
+import { PanelHomePage, PanelSectionPage } from "@/components/panels/PanelPages";
+import EmpreendimentoNovo from "@/pages/admin/EmpreendimentoNovo";
+import AdminMapa from "@/pages/admin/Mapa";
+import MapaInterativo from "@/pages/admin/MapaInterativo";
+import LotesVendas from "@/pages/admin/LotesVendas";
+import AprovacaoEmpreendimentos from "@/pages/admin/AprovacaoEmpreendimentos";
+import LotesPage from "@/pages/admin/Lotes";
+import FiliaisInternasPage from "@/pages/admin/FiliaisInternas";
+import ClientesSaasPage from "@/pages/admin/ClientesSaas";
+import FiliaisAccessPage from "@/pages/admin/FiliaisAccess";
+import UsuariosPage from "@/pages/admin/Usuarios";
+import AdminsFiliaisPage from "@/pages/admin/AdminsFiliais";
+import MapaSuperAdmin from "@/pages/admin/MapaSuperAdmin";
+
+export interface RouteConfig {
+  path: string;
+  element: React.ReactNode;
+  roles?: string[];
+  panelKey?: string;
+}
+
+export const publicRoutes: RouteConfig[] = [
+  { path: "/", element: <Index /> },
+  { path: "/whitepaper", element: <Whitepaper /> },
+  { path: "/acesso", element: <Acesso /> },
+  { path: "/login", element: <Login /> },
+  { path: "/signup", element: <Signup /> },
+  { path: "/reset", element: <Reset /> },
+  { path: "/login/super-admin", element: <LoginSuperAdmin /> },
+  { path: "/login/admin", element: <LoginAdmin /> },
+  { path: "/login/imobiliaria", element: <LoginImobiliaria /> },
+  { path: "/login/corretor", element: <LoginCorretor /> },
+  { path: "/login/juridico", element: <LoginJuridico /> },
+  { path: "/login/urbanismo", element: <LoginUrbanismo /> },
+  { path: "/login/contabilidade", element: <LoginContabilidade /> },
+  { path: "/login/marketing", element: <LoginMarketing /> },
+  { path: "/login/comercial", element: <LoginComercial /> },
+  { path: "/login/obras", element: <LoginObras /> },
+  { path: "/login/investidor", element: <LoginInvestidor /> },
+  { path: "/login/terrenista", element: <LoginTerrenista /> },
+  { path: "/logout", element: <Logout /> },
+  { path: "/acesso-negado", element: <AcessoNegado /> },
+  { path: "/debug/connection", element: <div style={{ all: 'initial' }}><div id="debug-connection-root"></div></div> },
+];
+
+export const panelRoutes: RouteConfig[] = [
+  // Super Admin
+  { path: "super-admin", element: <PanelHomePage menuKey="superadmin" title="Super Admin" />, roles: ["superadmin"] },
+  { path: "super-admin/admins-filiais", element: <AdminsFiliaisPage />, roles: ["superadmin"] },
+  { path: "super-admin/filiais-internas", element: <FiliaisInternasPage />, roles: ["superadmin"] },
+  { path: "super-admin/clientes-saas", element: <ClientesSaasPage />, roles: ["superadmin"] },
+  { path: "super-admin/filiais-acessos", element: <FiliaisAccessPage />, roles: ["superadmin"] },
+  { path: "super-admin/mapa", element: <MapaSuperAdmin />, roles: ["superadmin"] },
+  { path: "super-admin/relatorios", element: <PanelSectionPage menuKey="superadmin" title="Super Admin" section="Relatórios" />, roles: ["superadmin"] },
+  { path: "super-admin/config", element: <PanelSectionPage menuKey="superadmin" title="Super Admin" section="Configurações" />, roles: ["superadmin"] },
+  { path: "super-admin/organizacoes", element: <PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" />, roles: ["superadmin"] },
+  { path: "super-admin/usuarios", element: <UsuariosPage />, roles: ["superadmin"] },
+  { path: "super-admin/aprovacao", element: <AprovacaoEmpreendimentos />, roles: ["superadmin"] },
+
+  // Admin Filial
+  { path: "admin-filial", element: <PanelHomePage menuKey="adminfilial" title="Admin Filial" />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/relatorios", element: <PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Relatórios" />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/config", element: <PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Configurações" />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/equipe", element: <PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Equipe" />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/empreendimentos", element: <PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Empreendimentos" />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/empreendimentos/novo", element: <EmpreendimentoNovo />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/empreendimentos/editar/:id", element: <EmpreendimentoNovo />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/mapa", element: <AdminMapa />, roles: ["adminfilial", "superadmin"], panelKey: "urbanista" },
+  { path: "admin-filial/mapa-interativo", element: <MapaInterativo />, roles: ["adminfilial", "superadmin"], panelKey: "urbanista" },
+  { path: "admin-filial/lotes", element: <LotesPage />, roles: ["adminfilial", "superadmin"], panelKey: "adminfilial" },
+  { path: "admin-filial/lotes-vendas", element: <LotesVendas />, roles: ["adminfilial", "superadmin"], panelKey: "comercial" },
+
+  // Urbanista
+  { path: "urbanista", element: <PanelHomePage menuKey="urbanista" title="Urbanista" />, roles: ["urbanista"] },
+  { path: "urbanista/relatorios", element: <PanelSectionPage menuKey="urbanista" title="Urbanista" section="Relatórios" />, roles: ["urbanista"] },
+  { path: "urbanista/config", element: <PanelSectionPage menuKey="urbanista" title="Urbanista" section="Configurações" />, roles: ["urbanista"] },
+  { path: "urbanista/mapas", element: <PanelSectionPage menuKey="urbanista" title="Urbanista" section="Mapas" />, roles: ["urbanista"] },
+  { path: "urbanista/projetos", element: <PanelSectionPage menuKey="urbanista" title="Urbanista" section="Projetos" />, roles: ["urbanista"] },
+
+  // Jurídico
+  { path: "juridico", element: <PanelHomePage menuKey="juridico" title="Jurídico" />, roles: ["juridico"] },
+  { path: "juridico/relatorios", element: <PanelSectionPage menuKey="juridico" title="Jurídico" section="Relatórios" />, roles: ["juridico"] },
+  { path: "juridico/config", element: <PanelSectionPage menuKey="juridico" title="Jurídico" section="Configurações" />, roles: ["juridico"] },
+  { path: "juridico/contratos", element: <PanelSectionPage menuKey="juridico" title="Jurídico" section="Contratos" />, roles: ["juridico"] },
+  { path: "juridico/processos", element: <PanelSectionPage menuKey="juridico" title="Jurídico" section="Processos" />, roles: ["juridico"] },
+
+  // Contabilidade
+  { path: "contabilidade", element: <PanelHomePage menuKey="contabilidade" title="Contabilidade" />, roles: ["contabilidade"] },
+  { path: "contabilidade/relatorios", element: <PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Relatórios" />, roles: ["contabilidade"] },
+  { path: "contabilidade/config", element: <PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Configurações" />, roles: ["contabilidade"] },
+  { path: "contabilidade/financeiro", element: <PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Financeiro" />, roles: ["contabilidade"] },
+  { path: "contabilidade/fiscal", element: <PanelSectionPage menuKey="contabilidade" title="Contabilidade" section="Fiscal" />, roles: ["contabilidade"] },
+
+  // Marketing
+  { path: "marketing", element: <PanelHomePage menuKey="marketing" title="Marketing" />, roles: ["marketing"] },
+  { path: "marketing/relatorios", element: <PanelSectionPage menuKey="marketing" title="Marketing" section="Relatórios" />, roles: ["marketing"] },
+  { path: "marketing/config", element: <PanelSectionPage menuKey="marketing" title="Marketing" section="Configurações" />, roles: ["marketing"] },
+  { path: "marketing/campanhas", element: <PanelSectionPage menuKey="marketing" title="Marketing" section="Campanhas" />, roles: ["marketing"] },
+  { path: "marketing/materiais", element: <PanelSectionPage menuKey="marketing" title="Marketing" section="Materiais" />, roles: ["marketing"] },
+
+  // Comercial
+  { path: "comercial", element: <PanelHomePage menuKey="comercial" title="Comercial" />, roles: ["comercial"] },
+  { path: "comercial/relatorios", element: <PanelSectionPage menuKey="comercial" title="Comercial" section="Relatórios" />, roles: ["comercial"] },
+  { path: "comercial/config", element: <PanelSectionPage menuKey="comercial" title="Comercial" section="Configurações" />, roles: ["comercial"] },
+  { path: "comercial/leads", element: <PanelSectionPage menuKey="comercial" title="Comercial" section="Leads" />, roles: ["comercial"] },
+  { path: "comercial/propostas", element: <PanelSectionPage menuKey="comercial" title="Comercial" section="Propostas" />, roles: ["comercial"] },
+
+  // Imobiliária
+  { path: "imobiliaria", element: <PanelHomePage menuKey="imobiliaria" title="Imobiliária" />, roles: ["imobiliaria"] },
+  { path: "imobiliaria/relatorios", element: <PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Relatórios" />, roles: ["imobiliaria"] },
+  { path: "imobiliaria/config", element: <PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Configurações" />, roles: ["imobiliaria"] },
+  { path: "imobiliaria/corretores", element: <PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Corretores" />, roles: ["imobiliaria"] },
+  { path: "imobiliaria/leads", element: <PanelSectionPage menuKey="imobiliaria" title="Imobiliária" section="Leads" />, roles: ["imobiliaria"] },
+
+  // Corretor
+  { path: "corretor", element: <PanelHomePage menuKey="corretor" title="Corretor" />, roles: ["corretor"] },
+  { path: "corretor/relatorios", element: <PanelSectionPage menuKey="corretor" title="Corretor" section="Relatórios" />, roles: ["corretor"] },
+  { path: "corretor/config", element: <PanelSectionPage menuKey="corretor" title="Corretor" section="Configurações" />, roles: ["corretor"] },
+  { path: "corretor/leads", element: <PanelSectionPage menuKey="corretor" title="Corretor" section="Leads" />, roles: ["corretor"] },
+  { path: "corretor/vendas", element: <PanelSectionPage menuKey="corretor" title="Corretor" section="Vendas" />, roles: ["corretor"] },
+
+  // Obras
+  { path: "obras", element: <PanelHomePage menuKey="obras" title="Obras" />, roles: ["obras"] },
+  { path: "obras/relatorios", element: <PanelSectionPage menuKey="obras" title="Obras" section="Relatórios" />, roles: ["obras"] },
+  { path: "obras/config", element: <PanelSectionPage menuKey="obras" title="Obras" section="Configurações" />, roles: ["obras"] },
+  { path: "obras/cronograma", element: <PanelSectionPage menuKey="obras" title="Obras" section="Cronograma" />, roles: ["obras"] },
+  { path: "obras/andamento", element: <PanelSectionPage menuKey="obras" title="Obras" section="Andamento" />, roles: ["obras"] },
+
+  // Investidor
+  { path: "investidor", element: <PanelHomePage menuKey="investidor" title="Investidor" />, roles: ["investidor"] },
+  { path: "investidor/relatorios", element: <PanelSectionPage menuKey="investidor" title="Investidor" section="Relatórios" />, roles: ["investidor"] },
+  { path: "investidor/config", element: <PanelSectionPage menuKey="investidor" title="Investidor" section="Configurações" />, roles: ["investidor"] },
+  { path: "investidor/carteira", element: <PanelSectionPage menuKey="investidor" title="Investidor" section="Carteira" />, roles: ["investidor"] },
+  { path: "investidor/suporte", element: <PanelSectionPage menuKey="investidor" title="Investidor" section="Suporte" />, roles: ["investidor"] },
+
+  // Terrenista
+  { path: "terrenista", element: <PanelHomePage menuKey="terrenista" title="Terrenista" />, roles: ["terrenista"] },
+  { path: "terrenista/relatorios", element: <PanelSectionPage menuKey="terrenista" title="Terrenista" section="Relatórios" />, roles: ["terrenista"] },
+  { path: "terrenista/config", element: <PanelSectionPage menuKey="terrenista" title="Terrenista" section="Configurações" />, roles: ["terrenista"] },
+  { path: "terrenista/status", element: <PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" />, roles: ["terrenista"] },
+  { path: "terrenista/pagamentos", element: <PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" />, roles: ["terrenista"] },
+];

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 
 interface UserProfile {
@@ -24,6 +25,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any | null>(null);
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const location = useLocation();
 
   useEffect(() => {
     document.body.classList.add("bg-background", "text-foreground");
@@ -120,6 +122,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       subscription.unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    const segments = location.pathname.split("/").filter(Boolean);
+    const candidate = segments[0] || null;
+    const publicPrefixes = [
+      "login",
+      "signup",
+      "reset",
+      "acesso",
+      "whitepaper",
+      "logout",
+      "acesso-negado",
+      "debug",
+    ];
+    const filialFromPath = candidate && !publicPrefixes.includes(candidate) ? candidate : null;
+    setProfile(prev => (prev ? { ...prev, filial_id: filialFromPath } : prev));
+  }, [location.pathname]);
 
   const value = useMemo(() => ({ session, user, profile, loading }), [session, user, profile, loading]);
 


### PR DESCRIPTION
## Summary
- add route metadata module and dynamic mapping
- inject filialId from URL into auth session
- consume filialId from context in panel navigation components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a063cde3c4832a88bf13bfc93056b8