### PR TITLE
refactor: dedupe debug route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,10 +178,7 @@ const App = () => (
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
             
-            {/* Debug routes */}
-            <Route path="/debug/connection" element={<div style={{all:'initial'}}><div id="debug-connection-root"></div></div>} />
-            
-            {/* Load debug component dynamically */}
+            {/* Debug routes - loaded dinamicamente */}
             <Route path="/debug/connection" lazy={async () => {
               const Component = (await import("./app/debug/connection/page")).default;
               return { Component };


### PR DESCRIPTION
## Summary
- remove duplicate `/debug/connection` route and ensure lazy-loaded debug page

## Testing
- `npm run lint` *(fails: Unexpected any errors across project)*
- `npm run build`
- `curl -I http://localhost:4173/debug/connection`

------
https://chatgpt.com/codex/tasks/task_e_68a06d7cf854832aa3d21989bf96096c