### PR TITLE
Add superadmin new empreendimento route and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import AdminsFiliaisPage from "./pages/admin/AdminsFiliais";
 import AcessoNegado from "./pages/AcessoNegado";
 import { Protected } from "@/components/Protected";
 import MapaSuperAdmin from "./pages/admin/MapaSuperAdmin";
+import EmpreendimentoNovoSuperAdmin from "./pages/admin/EmpreendimentoNovoSuperAdmin";
 
 const queryClient = new QueryClient();
 
@@ -91,6 +92,8 @@ const App = () => (
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Configurações" /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />
+            <Route path="/super-admin/empreendimentos" element={<Protected allowedRoles={['superadmin']} panelKey="superadmin"><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Empreendimentos" /></Protected>} />
+            <Route path="/super-admin/empreendimentos/novo" element={<Protected allowedRoles={['superadmin']} panelKey="superadmin"><EmpreendimentoNovoSuperAdmin /></Protected>} />
 
             {/* Admin Filial - Rotas padronizadas em /admin-filial */}
             <Route path="/admin-filial" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelHomePage menuKey="adminfilial" title="Admin Filial" /></Protected>} />

--- a/src/components/panels/PanelPages.tsx
+++ b/src/components/panels/PanelPages.tsx
@@ -30,7 +30,7 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
         <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}>
           <div className="flex items-center justify-between gap-3 mb-4">
             <h2 className="text-xl font-semibold">Ações rápidas</h2>
-            <Link to="/admin-filial/empreendimentos/novo">
+            <Link to={menuKey === 'adminfilial' ? '/admin-filial/empreendimentos/novo' : '/super-admin/empreendimentos/novo'}>
               <Button variant="cta" className="gap-2"><Plus className="size-4" /> Novo Empreendimento</Button>
             </Link>
           </div>

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -18,6 +18,8 @@ export const NAV: Record<string, NavEntry[]> = {
     },
     { label: "Organizações", href: "/super-admin/organizacoes", icon: "building" },
     { label: "Usuários", href: "/super-admin/usuarios", icon: "user" },
+    { label: "Empreendimentos", href: "/super-admin/empreendimentos", icon: "building" },
+    { label: "Novo Empreendimento", href: "/super-admin/empreendimentos/novo", icon: "plus-circle" },
     { label: "Aprovação", href: "/super-admin/aprovacao", icon: "check-circle" },
     
     { label: "Relatórios", href: "/super-admin/relatorios", icon: "bar-chart-2" },

--- a/src/pages/admin/EmpreendimentoNovoSuperAdmin.tsx
+++ b/src/pages/admin/EmpreendimentoNovoSuperAdmin.tsx
@@ -1,0 +1,20 @@
+import { AppShell } from "@/components/shell/AppShell";
+
+export default function EmpreendimentoNovoSuperAdmin() {
+  return (
+    <AppShell
+      menuKey="superadmin"
+      breadcrumbs={[
+        { label: "Home", href: "/" },
+        { label: "Super Admin" },
+        { label: "Empreendimentos" },
+        { label: "Novo" }
+      ]}
+    >
+      <div className="text-center py-12">
+        <h1 className="text-2xl font-semibold">Novo Empreendimento</h1>
+        <p className="text-muted-foreground">Página em desenvolvimento.</p>
+      </div>
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add protected super admin route for listing and creating empreendimentos
- expose quick action link based on panel type
- introduce placeholder superadmin page and navigation entries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 71 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a1054fdcb0832a8b62730082a837c3