### PR TITLE
Conditional link to new empreendimento page based on menu key

### DIFF
--- a/src/components/panels/PanelPages.tsx
+++ b/src/components/panels/PanelPages.tsx
@@ -30,7 +30,7 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
         <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}>
           <div className="flex items-center justify-between gap-3 mb-4">
             <h2 className="text-xl font-semibold">Ações rápidas</h2>
-            <Link to="/admin-filial/empreendimentos/novo">
+            <Link to={menuKey === 'superadmin' ? '/super-admin/empreendimentos/novo' : '/admin-filial/empreendimentos/novo'}>
               <Button variant="cta" className="gap-2"><Plus className="size-4" /> Novo Empreendimento</Button>
             </Link>
           </div>


### PR DESCRIPTION
## Summary
- Navigate to super admin or admin filial new empreendimento form based on menu key

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 99 problems (71 errors, 28 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68a1086f6534832aa4cbbe8fff389cc4