### PR TITLE
refactor: load quick login credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,18 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Quick login credentials (development)
+
+The quick login widget can load test accounts from environment variables. Create or update `.env.local` with pairs of email and password for each role:
+
+```
+VITE_SUPERADMIN_EMAIL=superadmin@example.com
+VITE_SUPERADMIN_PASSWORD=strong-password
+VITE_ADMIN_EMAIL=admin@example.com
+VITE_ADMIN_PASSWORD=strong-password
+# repeat for other roles using the pattern
+# VITE_<ROLE>_EMAIL and VITE_<ROLE>_PASSWORD
+```
+
+Only roles with both variables defined will appear in the widget.

--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -18,6 +18,10 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
 
+  if (quickLoginCredentials.length === 0) {
+    return null;
+  }
+
   const quickLogin = async (cred: QuickLoginCredential) => {
     setError(null);
     setLoading(cred.email);

--- a/src/config/quickLogin.ts
+++ b/src/config/quickLogin.ts
@@ -9,18 +9,45 @@ export interface QuickLoginCredential {
   icon: LucideIcon;
 }
 
-export const quickLoginCredentials: QuickLoginCredential[] = [
-  { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
-  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
-  { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
-  { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
-  { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },
-  { email: 'marketing@blockurb.com', password: 'Market2024!', label: 'Marketing', role: 'marketing', panel: '/marketing', icon: User },
-  { email: 'comercial@blockurb.com', password: 'Venda2024!', label: 'Comercial', role: 'comercial', panel: '/comercial', icon: User },
-  { email: 'imobiliaria@blockurb.com', password: 'Imob2024!', label: 'Imobiliária', role: 'imobiliaria', panel: '/imobiliaria', icon: User },
-  { email: 'corretor@blockurb.com', password: 'Corret2024!', label: 'Corretor', role: 'corretor', panel: '/corretor', icon: User },
-  { email: 'obras@blockurb.com', password: 'Obras2024!', label: 'Obras', role: 'obras', panel: '/obras', icon: User },
-  { email: 'investidor@blockurb.com', password: 'Invest2024!', label: 'Investidor', role: 'investidor', panel: '/investidor', icon: User },
-  { email: 'terrenista@blockurb.com', password: 'Terra2024!', label: 'Terrenista', role: 'terrenista', panel: '/terrenista', icon: User },
+interface QuickLoginConfig {
+  envPrefix: string;
+  label: string;
+  role: string;
+  panel: string;
+  icon: LucideIcon;
+}
+
+const configs: QuickLoginConfig[] = [
+  { envPrefix: "SUPERADMIN", label: "Super Admin", role: "superadmin", panel: "/super-admin", icon: Crown },
+  { envPrefix: "ADMIN", label: "Admin Filial", role: "admin", panel: "/admin", icon: User },
+  { envPrefix: "URBANISTA", label: "Urbanista", role: "urbanista", panel: "/urbanista", icon: User },
+  { envPrefix: "JURIDICO", label: "Jurídico", role: "juridico", panel: "/juridico", icon: User },
+  { envPrefix: "CONTABILIDADE", label: "Contabilidade", role: "contabilidade", panel: "/contabilidade", icon: User },
+  { envPrefix: "MARKETING", label: "Marketing", role: "marketing", panel: "/marketing", icon: User },
+  { envPrefix: "COMERCIAL", label: "Comercial", role: "comercial", panel: "/comercial", icon: User },
+  { envPrefix: "IMOBILIARIA", label: "Imobiliária", role: "imobiliaria", panel: "/imobiliaria", icon: User },
+  { envPrefix: "CORRETOR", label: "Corretor", role: "corretor", panel: "/corretor", icon: User },
+  { envPrefix: "OBRAS", label: "Obras", role: "obras", panel: "/obras", icon: User },
+  { envPrefix: "INVESTIDOR", label: "Investidor", role: "investidor", panel: "/investidor", icon: User },
+  { envPrefix: "TERRENISTA", label: "Terrenista", role: "terrenista", panel: "/terrenista", icon: User }
 ];
+const env = import.meta.env as Record<string, string | undefined>;
+
+export const quickLoginCredentials: QuickLoginCredential[] = configs
+  .map((cfg) => {
+    const email = env[`VITE_${cfg.envPrefix}_EMAIL`];
+    const password = env[`VITE_${cfg.envPrefix}_PASSWORD`];
+
+    if (!email || !password) return null;
+
+    return {
+      email,
+      password,
+      label: cfg.label,
+      role: cfg.role,
+      panel: cfg.panel,
+      icon: cfg.icon
+    } satisfies QuickLoginCredential;
+  })
+  .filter((cred): cred is QuickLoginCredential => cred !== null);
 


### PR DESCRIPTION
## Summary
- remove hardcoded quick login emails and passwords
- load quick login accounts from environment variables and hide widget when none configured
- document quick login env setup for development

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1215481ac832a935a365b8e36f11f