### PR TITLE
refactor: rename admin role to adminfilial

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -39,7 +39,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || "/admin-filial");
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");
@@ -64,7 +64,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath }: LoginFormPro
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || "/admin-filial");
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -22,30 +22,30 @@ const sections = [
   {
     label: "Geral",
     items: [
-      { title: "Dashboard", url: "/admin", icon: LayoutDashboard },
-      { title: "Equipe", url: "/admin/equipe", icon: Users },
-      { title: "Leads", url: "/admin/leads", icon: Users },
-      { title: "Propostas", url: "/admin/propostas", icon: FileText },
+      { title: "Dashboard", url: "/admin-filial", icon: LayoutDashboard },
+      { title: "Equipe", url: "/admin-filial/equipe", icon: Users },
+      { title: "Leads", url: "/admin-filial/leads", icon: Users },
+      { title: "Propostas", url: "/admin-filial/propostas", icon: FileText },
     ],
   },
   {
     label: "Operação",
     items: [
-      { title: "Mapa", url: "/admin/mapa", icon: Map },
-      { title: "Obras", url: "/admin/obras", icon: Hammer },
+      { title: "Mapa", url: "/admin-filial/mapa", icon: Map },
+      { title: "Obras", url: "/admin-filial/obras", icon: Hammer },
     ],
   },
   {
     label: "Financeiro",
     items: [
-      { title: "Financeiro", url: "/admin/financeiro", icon: DollarSign },
-      { title: "Relatórios", url: "/admin/relatorios", icon: BarChart3 },
+      { title: "Financeiro", url: "/admin-filial/financeiro", icon: DollarSign },
+      { title: "Relatórios", url: "/admin-filial/relatorios", icon: BarChart3 },
     ],
   },
   {
     label: "Configurações",
     items: [
-      { title: "Configurações", url: "/admin/configuracoes", icon: Cog },
+      { title: "Configurações", url: "/admin-filial/configuracoes", icon: Cog },
     ],
   },
 ];

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -1,6 +1,6 @@
 export const scopeRoutes = {
   superadmin: "/super-admin",
-  admin: "/admin-filial",
+  adminfilial: "/admin-filial",
   imobiliaria: "/imobiliaria",
   corretor: "/corretor",
   juridico: "/juridico",
@@ -17,7 +17,7 @@ export type AuthScope = keyof typeof scopeRoutes;
 
 const scopeLabels: Record<AuthScope, string> = {
   superadmin: "Super Admin",
-  admin: "Admin Filial",
+  adminfilial: "Admin Filial",
   imobiliaria: "Imobiliária",
   corretor: "Corretores",
   juridico: "Jurídico",

--- a/src/config/quickLogin.ts
+++ b/src/config/quickLogin.ts
@@ -11,7 +11,7 @@ export interface QuickLoginCredential {
 
 export const quickLoginCredentials: QuickLoginCredential[] = [
   { email: 'superadmin@blockurb.com', password: 'BlockUrb2024!', label: 'Super Admin', role: 'superadmin', panel: '/super-admin', icon: Crown },
-  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'admin', panel: '/admin', icon: User },
+  { email: 'admin@blockurb.com', password: 'Admin2024!', label: 'Admin Filial', role: 'adminfilial', panel: '/admin-filial', icon: User },
   { email: 'urbanista@blockurb.com', password: 'Urban2024!', label: 'Urbanista', role: 'urbanista', panel: '/urbanista', icon: User },
   { email: 'juridico@blockurb.com', password: 'Legal2024!', label: 'Jurídico', role: 'juridico', panel: '/juridico', icon: User },
   { email: 'contabilidade@blockurb.com', password: 'Conta2024!', label: 'Contabilidade', role: 'contabilidade', panel: '/contabilidade', icon: User },

--- a/src/config/scopes.ts
+++ b/src/config/scopes.ts
@@ -1,6 +1,6 @@
 export const scopeRoutes = {
   superadmin: "/super-admin",
-  admin: "/admin-filial",
+  adminfilial: "/admin-filial",
   imobiliaria: "/imobiliaria",
   corretor: "/corretor",
   juridico: "/juridico",
@@ -18,7 +18,7 @@ export type AuthScope = keyof typeof scopeRoutes;
 export function labelFromScope(scope?: string) {
   const map: Record<string, string> = {
     superadmin: "Super Admin",
-    admin: "Admin Filial",
+    adminfilial: "Admin Filial",
     imobiliaria: "Imobiliária",
     corretor: "Corretor",
     juridico: "Jurídico",

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -28,7 +28,7 @@ const rows = [
 export default function AdminDashboard() {
   return (
     <Protected debugBypass={true}>
-      <AppShell breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin', href: '/admin' }, { label: 'Dashboard' }]}> 
+      <AppShell breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin Filial', href: '/admin-filial' }, { label: 'Dashboard' }]}> 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <KPIStat label="Lotes disponíveis" value={128} icon={<Building2 className="text-primary" />} />
           <KPIStat label="Reservas pendentes" value={12} icon={<FileText className="text-accent" />} tone="warning" />

--- a/src/pages/admin/MapaReal.tsx
+++ b/src/pages/admin/MapaReal.tsx
@@ -86,7 +86,7 @@ function SidebarEmpreendimentos({ onSelect, activeId }: { onSelect: (e: Empreend
               >
                 <div className="flex items-center justify-between">
                   <div className="font-medium text-sm">{e.nome}</div>
-                  <a href={`/admin?empreendimento=${e.id}`} onClick={(ev)=>ev.stopPropagation()} className="text-xs text-primary underline">Abrir no painel</a>
+                  <a href={`/admin-filial?empreendimento=${e.id}`} onClick={(ev)=>ev.stopPropagation()} className="text-xs text-primary underline">Abrir no painel</a>
                 </div>
                 <div className="mt-2 text-xs text-muted-foreground">
                   Criado em: {new Date(e.created_at).toLocaleDateString('pt-BR')}

--- a/src/pages/login/Admin.tsx
+++ b/src/pages/login/Admin.tsx
@@ -3,7 +3,7 @@ import AuthLayout from "@/components/auth/AuthLayout";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { labelFromScope, pathFromScope } from "@/config/authConfig";
 
-const SCOPE = "admin" as const;
+const SCOPE = "adminfilial" as const;
 
 export default function LoginAdmin() {
   const TITLE = `Entrar — ${labelFromScope(SCOPE)}`;


### PR DESCRIPTION
## Summary
- map admin quick login credential to new `adminfilial` role and `/admin-filial` panel
- rename admin scope to `adminfilial` across configs
- update login and navigation components to target `adminfilial` scope and routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a12134103c832a859b835db3fd138f