### PR TITLE
Integrate Supabase data and Leaflet map

### DIFF
--- a/src/components/app/LotesMapPreview.tsx
+++ b/src/components/app/LotesMapPreview.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { supabase } from '@/lib/dataClient';
+
+interface Props {
+  empreendimentoId?: string;
+  height?: string;
+}
+
+// Simple Leaflet map that loads lot polygons via RPC lotes_geojson
+export function LotesMapPreview({ empreendimentoId, height = '380px' }: Props) {
+  const mapRef = useRef<L.Map | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const layerRef = useRef<L.GeoJSON | null>(null);
+
+  useEffect(() => {
+    if (mapRef.current || !containerRef.current) return;
+    const map = L.map(containerRef.current, {
+      center: [-23.5489, -46.6388],
+      zoom: 13,
+      zoomControl: false,
+    });
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap'
+    }).addTo(map);
+    mapRef.current = map;
+    return () => { map.remove(); mapRef.current = null; };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !empreendimentoId) return;
+
+    supabase
+      .rpc('lotes_geojson', { p_empreendimento_id: empreendimentoId })
+      .then(({ data }) => {
+        if (!data) return;
+        if (layerRef.current) {
+          map.removeLayer(layerRef.current);
+          layerRef.current = null;
+        }
+        const layer = L.geoJSON(data as any, {
+          style: (feature) => {
+            const status = feature?.properties?.status || 'disponivel';
+            switch (status) {
+              case 'reservado': return { color: '#EAB308', fillColor: '#EAB308', fillOpacity: 0.25, weight: 2 };
+              case 'vendido': return { color: '#EF4444', fillColor: '#EF4444', fillOpacity: 0.25, weight: 2 };
+              default: return { color: '#00C26E', fillColor: '#00C26E', fillOpacity: 0.25, weight: 2 };
+            }
+          }
+        }).addTo(map);
+        layerRef.current = layer;
+        const bounds = layer.getBounds();
+        if (bounds.isValid()) map.fitBounds(bounds, { padding: [20, 20] });
+      });
+  }, [empreendimentoId]);
+
+  return <div ref={containerRef} style={{ height }} />;
+}

--- a/src/components/panels/PanelPages.tsx
+++ b/src/components/panels/PanelPages.tsx
@@ -9,6 +9,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Building2, FileText, Target, Plus, Wrench } from "lucide-react";
 import { adminTeamColumns, adminTeamRows } from "@/mocks/tables";
 import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useFilterOptions } from "@/hooks/useFilterOptions";
+import { LotesMapPreview } from "@/components/app/LotesMapPreview";
 
 const DevelopmentPlaceholder = ({ panelName }: { panelName: string }) => (
   <div className="rounded-[14px] border border-dashed border-border bg-secondary/60 h-[calc(100vh-200px)] grid place-items-center text-center p-4">
@@ -23,11 +26,15 @@ const DevelopmentPlaceholder = ({ panelName }: { panelName: string }) => (
 );
 
 export function PanelHomePage({ menuKey, title }: { menuKey: string; title: string }) {
+  const { empreendimentos, statuses } = useFilterOptions();
+  const [selectedEmpreendimento, setSelectedEmpreendimento] = useState<string>('');
+  const [status, setStatus] = useState<string>('todos');
+
   // Mantém o dashboard completo para os painéis funcionais
   if (menuKey === 'superadmin' || menuKey === 'adminfilial') {
     return (
       <Protected>
-        <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}>
+        <AppShell menuKey={menuKey} breadcrumbs={[{ label: 'Home', href: '/' }, { label: title }]}> 
           <div className="flex items-center justify-between gap-3 mb-4">
             <h2 className="text-xl font-semibold">Ações rápidas</h2>
             <Link to={menuKey === 'superadmin' ? '/super-admin/empreendimentos/novo' : '/admin-filial/empreendimentos/novo'}>
@@ -43,22 +50,26 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
 
           <div className="mt-6">
             <FiltersBar>
-              {/* TODO: ligar selects a dados reais */}
-              <Select defaultValue="alfa">
-                <SelectTrigger className="w-[200px]"><SelectValue placeholder="Empreendimento" /></SelectTrigger>
+              <Select value={selectedEmpreendimento} onValueChange={setSelectedEmpreendimento}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue placeholder="Empreendimento" />
+                </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="alfa">Alfa</SelectItem>
-                  <SelectItem value="beta">Beta</SelectItem>
+                  {empreendimentos.map((e) => (
+                    <SelectItem key={e.id} value={e.id}>{e.nome}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
 
-              <Select defaultValue="todos">
-                <SelectTrigger className="w-[200px]"><SelectValue placeholder="Status" /></SelectTrigger>
+              <Select value={status} onValueChange={setStatus}>
+                <SelectTrigger className="w-[200px]">
+                  <SelectValue placeholder="Status" />
+                </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="todos">Todos</SelectItem>
-                  <SelectItem value="disponivel">Disponível</SelectItem>
-                  <SelectItem value="reservado">Reservado</SelectItem>
-                  <SelectItem value="vendido">Vendido</SelectItem>
+                  {statuses.map((s) => (
+                    <SelectItem key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
 
@@ -77,13 +88,12 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
           </div>
 
           <div className="mt-8">
-            <h3 className="mb-2 font-semibold">Mapa (placeholder)</h3>
-            <div className="rounded-[14px] border border-border bg-secondary/60 h-[380px] grid place-items-center text-sm text-muted-foreground">
-              {/* TODO: integrar Leaflet + RPC lotes_geojson */}
-              Integração futura com Leaflet / RPC lotes_geojson
-              <div className="mt-4">
-                <Button variant="outline">Abrir mapa completo</Button>
-              </div>
+            <h3 className="mb-2 font-semibold">Mapa</h3>
+            <div className="rounded-[14px] border border-border bg-secondary/60 h-[380px] overflow-hidden">
+              <LotesMapPreview empreendimentoId={selectedEmpreendimento} height="100%" />
+            </div>
+            <div className="mt-4">
+              <Button variant="outline">Abrir mapa completo</Button>
             </div>
           </div>
         </AppShell>

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,5 +1,7 @@
 import { Heading } from "@/components/ui/Heading";
 import { Section } from "@/components/ui/Section";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
 
 interface TestimonialProps {
   quote: string;
@@ -20,20 +22,24 @@ function TestimonialCard({ quote, name, role }: TestimonialProps) {
 }
 
 export function TestimonialsSection() {
-  const testimonials: TestimonialProps[] = [
-    { quote: "Operação leve, processos claros e suporte 360°. Resultado em tempo recorde.", name: "Mariana S.", role: "Franqueada • MG" },
-    { quote: "Tokenização parcial abriu um novo público e acelerou a captação.", name: "Rafael T.", role: "Investidor • SP" },
-    { quote: "Transformamos a gleba em um projeto vendável com previsibilidade.", name: "João P.", role: "Terrenista • PR" },
-    { quote: "Painéis claros. Consegui gerir equipe e funil sem planilhas.", name: "Carlos M.", role: "Admin Filial • RS" },
-    { quote: "Relatórios confiáveis e auditoria facilitada reduziram retrabalho.", name: "Lívia A.", role: "Contabilidade • SP" },
-  ];
+  const [testimonials, setTestimonials] = useState<TestimonialProps[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from('testemunhos')
+      .select('quote, name, role')
+      .then(({ data }) => {
+        if (data) setTestimonials(data);
+      });
+  }, []);
 
   const loop = [...testimonials, ...testimonials];
+
+  if (testimonials.length === 0) return null;
 
   return (
     <Section id="testemunhos">
       <Heading as="h3" className="text-xl sm:text-2xl">O que dizem os parceiros</Heading>
-      {/* TODO: Substituir por depoimentos reais vindos da base quando integrar Supabase */}
       <div className="mt-6 marquee" aria-label="Depoimentos de parceiros em rolagem contínua">
         <div className="marquee-track" style={{ ['--marquee-duration' as any]: '65s' }}>
           {loop.map((t, i) => (

--- a/src/hooks/useFilterOptions.ts
+++ b/src/hooks/useFilterOptions.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/dataClient';
+
+interface Empreendimento {
+  id: string;
+  nome: string;
+}
+
+/**
+ * Fetches empreendimentos and distinct lote statuses from Supabase
+ */
+export function useFilterOptions() {
+  const [empreendimentos, setEmpreendimentos] = useState<Empreendimento[]>([]);
+  const [statuses, setStatuses] = useState<string[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from('empreendimentos')
+      .select('id, nome')
+      .order('nome')
+      .then(({ data }) => {
+        if (data) setEmpreendimentos(data);
+      });
+
+    supabase
+      .from('lotes')
+      .select('status')
+      .then(({ data }) => {
+        if (data) {
+          const unique = Array.from(new Set(data.map(d => d.status).filter(Boolean)));
+          setStatuses(unique as string[]);
+        }
+      });
+  }, []);
+
+  return { empreendimentos, statuses };
+}
+
+export type { Empreendimento };

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -7,6 +7,9 @@ import { WeeklySalesChart } from "@/components/app/WeeklySalesChart";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Building2, FileText, Target } from "lucide-react";
+import { useState } from "react";
+import { useFilterOptions } from "@/hooks/useFilterOptions";
+import { LotesMapPreview } from "@/components/app/LotesMapPreview";
 
 const columns = [
   { key: 'nome', header: 'Nome' },
@@ -26,6 +29,10 @@ const rows = [
 ];
 
 export default function AdminDashboard() {
+  const { empreendimentos, statuses } = useFilterOptions();
+  const [selectedEmpreendimento, setSelectedEmpreendimento] = useState<string>('');
+  const [status, setStatus] = useState<string>('todos');
+
   return (
     <Protected debugBypass={true}>
       <AppShell breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin', href: '/admin' }, { label: 'Dashboard' }]}> 
@@ -38,22 +45,26 @@ export default function AdminDashboard() {
 
         <div className="mt-6">
           <FiltersBar>
-            {/* TODO: ligar selects a dados reais */}
-            <Select defaultValue="alfa">
-              <SelectTrigger className="w-[200px]"><SelectValue placeholder="Empreendimento" /></SelectTrigger>
+            <Select value={selectedEmpreendimento} onValueChange={setSelectedEmpreendimento}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Empreendimento" />
+              </SelectTrigger>
               <SelectContent>
-                <SelectItem value="alfa">Alfa</SelectItem>
-                <SelectItem value="beta">Beta</SelectItem>
+                {empreendimentos.map((e) => (
+                  <SelectItem key={e.id} value={e.id}>{e.nome}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
 
-            <Select defaultValue="todos">
-              <SelectTrigger className="w-[200px]"><SelectValue placeholder="Status" /></SelectTrigger>
+            <Select value={status} onValueChange={setStatus}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
               <SelectContent>
                 <SelectItem value="todos">Todos</SelectItem>
-                <SelectItem value="disponivel">Disponível</SelectItem>
-                <SelectItem value="reservado">Reservado</SelectItem>
-                <SelectItem value="vendido">Vendido</SelectItem>
+                {statuses.map((s) => (
+                  <SelectItem key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
 
@@ -72,13 +83,12 @@ export default function AdminDashboard() {
         </div>
 
         <div className="mt-8">
-          <h3 className="mb-2 font-semibold">Mapa (placeholder)</h3>
-          <div className="rounded-[14px] border border-border bg-secondary/60 h-[380px] grid place-items-center text-sm text-muted-foreground">
-            {/* TODO: integrar Leaflet + RPC lotes_geojson */}
-            Integração futura com Leaflet / RPC lotes_geojson
-            <div className="mt-4">
-              <Button variant="outline">Abrir mapa completo</Button>
-            </div>
+          <h3 className="mb-2 font-semibold">Mapa</h3>
+          <div className="rounded-[14px] border border-border bg-secondary/60 h-[380px] overflow-hidden">
+            <LotesMapPreview empreendimentoId={selectedEmpreendimento} height="100%" />
+          </div>
+          <div className="mt-4">
+            <Button variant="outline">Abrir mapa completo</Button>
           </div>
         </div>
       </AppShell>


### PR DESCRIPTION
## Summary
- load empreendimentos and lote statuses from Supabase for dashboard filters
- embed Leaflet preview map fed by `lotes_geojson` RPC
- fetch testimonials from Supabase instead of static content

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1215f9cd0832a929ade579bcafe78