### PR TITLE
feat: hide quick login in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,5 @@ VITE_ADMIN_PASSWORD=strong-password
 ```
 
 Only roles with both variables defined will appear in the widget.
+
+This quick login widget is available only during development and returns nothing in production builds.

--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -18,6 +18,10 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
 
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
   if (quickLoginCredentials.length === 0) {
     return null;
   }


### PR DESCRIPTION
## Summary
- hide QuickLoginWidget outside development using runtime check
- document that quick login widget is only for development

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a123c526a8832a9b8757be41242c6f