### PR TITLE
Improve error handling in map and login components

### DIFF
--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -41,7 +41,7 @@ export function QuickLoginWidget({ compact = false, className = "" }: QuickLogin
         navigate(cred.panel);
       }
     } catch (err) {
-      setError("Erro inesperado ao fazer login");
+      setError(err instanceof Error ? err.message : "Erro inesperado ao fazer login");
     } finally {
       setLoading(null);
     }

--- a/src/hooks/useFilterOptions.ts
+++ b/src/hooks/useFilterOptions.ts
@@ -12,20 +12,29 @@ interface Empreendimento {
 export function useFilterOptions() {
   const [empreendimentos, setEmpreendimentos] = useState<Empreendimento[]>([]);
   const [statuses, setStatuses] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     supabase
       .from('empreendimentos')
       .select('id, nome')
       .order('nome')
-      .then(({ data }) => {
+      .then(({ data, error }) => {
+        if (error) {
+          setError(error.message || 'Erro ao carregar empreendimentos');
+          return;
+        }
         if (data) setEmpreendimentos(data);
       });
 
     supabase
       .from('lotes')
       .select('status')
-      .then(({ data }) => {
+      .then(({ data, error }) => {
+        if (error) {
+          setError(error.message || 'Erro ao carregar statuses');
+          return;
+        }
         if (data) {
           const unique = Array.from(new Set(data.map(d => d.status).filter(Boolean)));
           setStatuses(unique as string[]);
@@ -33,7 +42,7 @@ export function useFilterOptions() {
       });
   }, []);
 
-  return { empreendimentos, statuses };
+  return { empreendimentos, statuses, error };
 }
 
 export type { Empreendimento };


### PR DESCRIPTION
## Summary
- add error state and UI overlay to `MapView` for failed lot requests or status updates
- surface unexpected login errors in `QuickLoginWidget`
- return error information from `useFilterOptions` hook when Supabase queries fail

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a123cd7e14832a8cf97b4190f13042