### PR TITLE
refactor: replace any with interfaces

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   }
 );

--- a/src/app/debug/connection/page.tsx
+++ b/src/app/debug/connection/page.tsx
@@ -10,8 +10,8 @@ export default function DebugConnection() {
       try {
         const { error } = await supabase.from('empreendimentos').select('id').limit(1)
         setMsg(error ? `Conectado, mas erro de consulta: ${error.message}` : 'Conectado — consulta OK.')
-      } catch (e: any) {
-        setMsg(`Erro de conexão: ${e?.message || 'Erro desconhecido'}`)
+        } catch (e) {
+          setMsg(`Erro de conexão: ${e instanceof Error ? e.message : 'Erro desconhecido'}`)
       }
     })()
   }, [])

--- a/src/components/app/DataTable.tsx
+++ b/src/components/app/DataTable.tsx
@@ -2,9 +2,13 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export interface Column { key: string; header: string }
-export interface DataTableProps { columns: Column[]; rows: Record<string, any>[]; pageSize?: number }
+export interface DataTableProps<T extends Record<string, unknown>> {
+  columns: Column[];
+  rows: T[];
+  pageSize?: number;
+}
 
-export function DataTable({ columns, rows, pageSize = 5 }: DataTableProps) {
+export function DataTable<T extends Record<string, unknown>>({ columns, rows, pageSize = 5 }: DataTableProps<T>) {
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [page, setPage] = useState(0);

--- a/src/components/app/LotesMapPreview.tsx
+++ b/src/components/app/LotesMapPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import L from 'leaflet';
+import type { GeoJsonObject } from 'geojson';
 import 'leaflet/dist/leaflet.css';
 import { supabase } from '@/lib/dataClient';
 
@@ -34,18 +35,18 @@ export function LotesMapPreview({ empreendimentoId, height = '380px' }: Props) {
 
     supabase
       .rpc('lotes_geojson', { p_empreendimento_id: empreendimentoId })
-      .then(({ data }) => {
-        if (!data) return;
-        if (layerRef.current) {
-          map.removeLayer(layerRef.current);
-          layerRef.current = null;
-        }
-        const layer = L.geoJSON(data as any, {
-          style: (feature) => {
-            const status = feature?.properties?.status || 'disponivel';
-            switch (status) {
-              case 'reservado': return { color: '#EAB308', fillColor: '#EAB308', fillOpacity: 0.25, weight: 2 };
-              case 'vendido': return { color: '#EF4444', fillColor: '#EF4444', fillOpacity: 0.25, weight: 2 };
+        .then(({ data }) => {
+          if (!data) return;
+          if (layerRef.current) {
+            map.removeLayer(layerRef.current);
+            layerRef.current = null;
+          }
+          const layer = L.geoJSON(data as GeoJsonObject, {
+            style: (feature) => {
+              const status = feature?.properties?.status || 'disponivel';
+              switch (status) {
+                case 'reservado': return { color: '#EAB308', fillColor: '#EAB308', fillOpacity: 0.25, weight: 2 };
+                case 'vendido': return { color: '#EF4444', fillColor: '#EF4444', fillOpacity: 0.25, weight: 2 };
               default: return { color: '#00C26E', fillColor: '#00C26E', fillOpacity: 0.25, weight: 2 };
             }
           }

--- a/src/components/sections/LogoRow.tsx
+++ b/src/components/sections/LogoRow.tsx
@@ -15,8 +15,8 @@ export function LogoRowSection() {
       <div className="flex flex-col gap-6">
         <Heading as="h3" className="text-center text-xl sm:text-2xl">Parcerias e mídias</Heading>
         {/* TODO: Substituir por logos reais e links quando houver integrações oficiais */}
-        <div className="marquee" aria-label="Logos de parcerias e mídias em rolagem contínua">
-          <div className="marquee-track" style={{ ['--marquee-duration' as any]: '55s' }}>
+          <div className="marquee" aria-label="Logos de parcerias e mídias em rolagem contínua">
+            <div className="marquee-track" style={{ ['--marquee-duration' as string]: '55s' }}>
             {loop.map((name, i) => (
               <div
                 key={i}

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -40,8 +40,8 @@ export function TestimonialsSection() {
   return (
     <Section id="testemunhos">
       <Heading as="h3" className="text-xl sm:text-2xl">O que dizem os parceiros</Heading>
-      <div className="mt-6 marquee" aria-label="Depoimentos de parceiros em rolagem contínua">
-        <div className="marquee-track" style={{ ['--marquee-duration' as any]: '65s' }}>
+        <div className="mt-6 marquee" aria-label="Depoimentos de parceiros em rolagem contínua">
+          <div className="marquee-track" style={{ ['--marquee-duration' as string]: '65s' }}>
           {loop.map((t, i) => (
             <div key={i} className="w-[320px]">
               <TestimonialCard {...t} />

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -12,7 +12,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
-import { NAV, inferMenuKey } from "@/config/nav";
+import { NAV, inferMenuKey, type NavEntry } from "@/config/nav";
 import { useAuth } from "@/providers/AuthProvider";
 import {
   LayoutDashboard,
@@ -32,10 +32,15 @@ import {
   Circle,
   CheckCircle,
   PlusCircle,
+  type LucideIcon,
 } from "lucide-react";
 
-function IconByName({ name }: { name?: string }) {
-  const map: Record<string, any> = {
+interface IconByNameProps {
+  name?: string;
+}
+
+function IconByName({ name }: IconByNameProps) {
+  const map: Record<string, LucideIcon> = {
     layout: LayoutDashboard,
     "layout-dashboard": LayoutDashboard,
     users: Users,
@@ -55,19 +60,23 @@ function IconByName({ name }: { name?: string }) {
     "check-circle": CheckCircle,
     "plus-circle": PlusCircle,
   };
-  const Comp = (name && map[name]) || Circle;
+  const Comp: LucideIcon = (name && map[name]) || Circle;
   return <Comp className="mr-2 h-4 w-4" />;
 }
 
-export function AppSidebar({ menuKey }: { menuKey?: string }) {
+export interface AppSidebarProps {
+  menuKey?: string;
+}
+
+export function AppSidebar({ menuKey }: AppSidebarProps) {
   const location = useLocation();
   const current = location.pathname;
   const key = menuKey || inferMenuKey(current);
   const { profile } = useAuth();
-  const rawItems = NAV[key] || [];
+  const rawItems: NavEntry[] = NAV[key] || [];
   const isSuperAdmin = profile?.role === 'superadmin';
   const panels = Array.isArray(profile?.panels) ? (profile?.panels as string[]) : [];
-  const items = rawItems.filter((item: any) => {
+  const items = rawItems.filter((item) => {
     // Se não tiver panelKey, sempre mostra
     if (!item.panelKey) return true;
     // Super Admin sempre vê
@@ -89,12 +98,12 @@ export function AppSidebar({ menuKey }: { menuKey?: string }) {
           <SidebarGroupLabel>Menu</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {items.map((item) => (
+              {items.map((item: NavEntry) => (
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton asChild isActive={current === item.href}>
                     <NavLink to={item.href} className={({ isActive }) => cn(isActive && "text-primary font-medium") }>
                       <IconByName name={item.icon} />
-                      <span>{(item as any).label ?? (item as any).title}</span>
+                      <span>{item.label ?? item.title}</span>
                     </NavLink>
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -17,7 +17,7 @@ export function Section({ id, className, container = true, children }: PropsWith
   );
 
   return (
-    <section id={id} ref={ref as any} className="opacity-0 py-16">
+    <section id={id} ref={ref} className="opacity-0 py-16">
       {container ? <div className="container">{children}</div> : Inner}
     </section>
   );

--- a/src/lib/geojsonUtils.ts
+++ b/src/lib/geojsonUtils.ts
@@ -9,13 +9,23 @@ export interface LoteData {
   area_m2: number;
   coordenadas: { lat: number; lng: number };
   geometria: number[][][];
-  properties: any;
+  properties: GeoJSONProperties;
   status?: 'disponivel' | 'reservado' | 'vendido';
+}
+
+export interface GeoJSONProperties {
+  Name?: string;
+  name?: string;
+  NOME?: string;
+  nome?: string;
+  label?: string;
+  description?: string;
+  [key: string]: unknown;
 }
 
 export interface GeoJSONFeature {
   type: 'Feature';
-  properties: { [key: string]: any };
+  properties: GeoJSONProperties;
   geometry: {
     type: 'Polygon';
     coordinates: number[][][];
@@ -108,7 +118,7 @@ export function calculateBounds(features: GeoJSONFeature[]): { sw: { lat: number
 /**
  * Extrai nome do lote das properties
  */
-export function extractLoteName(properties: any, index: number): string {
+export function extractLoteName(properties: GeoJSONProperties, index: number): string {
   const name = properties?.Name || 
                properties?.name || 
                properties?.NOME || 


### PR DESCRIPTION
## Summary
- add typed interfaces for sidebar nav items and icons
- define GeoJSON property types and safer helpers
- make utility components and data table generics type-safe
- warn on explicit any via eslint rule

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a123beb280832aadad9145d82dcb89