### PR TITLE
fix: ensure unaccent extension

### DIFF
--- a/NovoSetup/sql/sql.final.referenciado.sql
+++ b/NovoSetup/sql/sql.final.referenciado.sql
@@ -1,6 +1,9 @@
 -- Estrutura consolidada com referências aos scripts existentes
 -- Base deduzida do código-fonte + ajustes de app.final.sql e outros
 
+-- Extensões necessárias
+create extension if not exists unaccent;
+
 -- Funções utilitárias (de app.final.sql)
 create or replace function public.set_updated_at()
 returns trigger language plpgsql as $$


### PR DESCRIPTION
## Summary
- ensure the unaccent extension is created before defining slugify

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a14ba95fac832ab9f9a6c979ed999c