### PR TITLE
Handle get_my_profile errors in AuthorizationProvider

### DIFF
--- a/src/providers/AuthorizationProvider.tsx
+++ b/src/providers/AuthorizationProvider.tsx
@@ -28,21 +28,34 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
         return;
       }
       setLoading(true);
-      const { data } = await supabase.rpc('get_my_profile').single();
-      if (data) {
-        setProfile({
-          role: data.role || user.app_metadata?.role || 'user',
-          panels: Array.isArray(data.panels) ? data.panels : [],
-          filial_id: data.filial_id ?? null,
-        });
-      } else {
+      try {
+        const { data, error } = await supabase.rpc('get_my_profile').single();
+        if (error) {
+          console.error('Erro ao chamar get_my_profile:', error);
+        }
+        if (data) {
+          setProfile({
+            role: data.role || user.app_metadata?.role || 'user',
+            panels: Array.isArray(data.panels) ? data.panels : [],
+            filial_id: data.filial_id ?? null,
+          });
+        } else {
+          setProfile({
+            role: user.app_metadata?.role || 'user',
+            panels: [],
+            filial_id: null,
+          });
+        }
+      } catch (err) {
+        console.error('Erro inesperado ao chamar get_my_profile:', err);
         setProfile({
           role: user.app_metadata?.role || 'user',
           panels: [],
           filial_id: null,
         });
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
     };
     load();
   }, [user?.id]);


### PR DESCRIPTION
## Summary
- log failures from `get_my_profile` RPC in the auth provider
- ensure profile loading handles errors gracefully

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15521a490832a9d661c2ce656b20d