### PR TITLE
feat: return panels jsonb in get_my_profile

### DIFF
--- a/NovoSetup/sql/sql.final.referenciado.sql
+++ b/NovoSetup/sql/sql.final.referenciado.sql
@@ -345,6 +345,33 @@ $$;
 
 grant execute on function public.approve_empreendimento(uuid, boolean, text) to authenticated;
 
+-- Função para obter o perfil do usuário autenticado
+create or replace function public.get_my_profile()
+returns table(
+    user_id uuid,
+    email text,
+    full_name text,
+    role text,
+    panels jsonb,
+    is_active boolean,
+    filial_id uuid,
+    updated_at timestamptz
+)
+language plpgsql
+security definer
+as $$
+begin
+  return query
+  select user_id, email, full_name, role,
+         to_jsonb(panels) as panels,
+         is_active, filial_id, updated_at
+  from public.user_profiles
+  where user_id = auth.uid();
+end;
+$$;
+
+grant execute on function public.get_my_profile() to authenticated;
+
 -- RPCs de lotes
 create or replace function public.lotes_geojson(p_empreendimento_id uuid)
 returns jsonb

--- a/NovoSetup/sql/sqlsemreferencia.sql
+++ b/NovoSetup/sql/sqlsemreferencia.sql
@@ -82,3 +82,30 @@ create table testemunhos (
     role text
 );
 
+-- Função para obter o perfil do usuário autenticado
+create or replace function get_my_profile()
+returns table(
+    user_id uuid,
+    email text,
+    full_name text,
+    role text,
+    panels jsonb,
+    is_active boolean,
+    filial_id uuid,
+    created_at timestamptz
+)
+language plpgsql
+security definer
+as $$
+begin
+  return query
+  select user_id, email, full_name, role,
+         to_jsonb(panels) as panels,
+         is_active, filial_id, created_at
+  from user_profiles
+  where user_id = auth.uid();
+end;
+$$;
+
+grant execute on function get_my_profile() to authenticated;
+


### PR DESCRIPTION
## Summary
- convert panels to JSONB in get_my_profile RPC
- include new function in NovoSetup scripts
- rewrite get_my_profile with plpgsql to avoid SQL parse issues

## Testing
- `npm test`
- `curl -i -X POST https://epsuxumkgakpqykvteij.supabase.co/rest/v1/rpc/exec -d '{"sql":"select 1"}'` (fails: 403 CONNECT tunnel)


------
https://chatgpt.com/codex/tasks/task_e_68a157bb70fc832a85aee48f2a8eeb4b