### PR TITLE
Populate user_profiles on signup

### DIFF
--- a/NovoSetup/sql/migrations/20250816120000_user_profile_trigger.sql
+++ b/NovoSetup/sql/migrations/20250816120000_user_profile_trigger.sql
@@ -1,0 +1,18 @@
+-- Popula automaticamente user_profiles ao cadastrar usuário
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.user_profiles (user_id, email, full_name, role)
+  values (new.id, new.email, coalesce(new.raw_user_meta_data->>'full_name', ''), 'investidor');
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_user();
+

--- a/NovoSetup/sql/sqlsemreferencia.sql
+++ b/NovoSetup/sql/sqlsemreferencia.sql
@@ -25,6 +25,23 @@ create table user_profiles (
     created_at timestamptz default now()
 );
 
+-- Trigger para preencher user_profiles ao registrar um novo usuário
+create or replace function handle_new_user()
+returns trigger
+language plpgsql
+security definer
+as $$
+begin
+  insert into user_profiles (user_id, email, full_name, role)
+  values (new.id, new.email, coalesce(new.raw_user_meta_data->>'full_name', ''), 'investidor');
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function handle_new_user();
+
 create table filial_allowed_panels (
     filial_id uuid references filiais(id) on delete cascade,
     panel text not null,

--- a/POPULACAO_AUTOMATICA_USER_PROFILES.md
+++ b/POPULACAO_AUTOMATICA_USER_PROFILES.md
@@ -1,0 +1,11 @@
+# ✅ População automática de user_profiles
+
+## 🗄️ Alterações
+- Função `handle_new_user` e trigger `on_auth_user_created` preenchem `user_profiles` com `role` padrão `investidor` sempre que um novo usuário é criado.
+
+### Executar
+- Rodar `NovoSetup/sql/sql.final.referenciado.sql` ou a migration `NovoSetup/sql/migrations/20250816120000_user_profile_trigger.sql` no Supabase.
+
+## 🧪 Testar
+1. Acesse `/signup` e cadastre um usuário.
+2. Verifique na tabela `user_profiles` se o registro foi criado com `role = 'investidor'.`


### PR DESCRIPTION
## Summary
- auto-fill user_profiles with role `investidor` for new users
- add SQL trigger/migration and documentation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a175e7c710832a90f71d55a240abb8