### PR TITLE
fix: prevent early profile fetch without session

### DIFF
--- a/src/providers/AuthorizationProvider.tsx
+++ b/src/providers/AuthorizationProvider.tsx
@@ -16,15 +16,15 @@ interface AuthorizationState {
 const AuthorizationContext = createContext<AuthorizationState>({ profile: null, loading: true });
 
 export function AuthorizationProvider({ children }: { children: React.ReactNode }) {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const [profile, setProfile] = useState<AuthorizationProfile | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const load = async () => {
-      if (!user) {
+      if (authLoading || !user) {
         setProfile(null);
-        setLoading(false);
+        setLoading(authLoading);
         return;
       }
       setLoading(true);
@@ -83,7 +83,7 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
       }
     };
     load();
-  }, [user?.id]);
+  }, [user, authLoading]);
 
   const value = useMemo(() => ({ profile, loading }), [profile, loading]);
   return <AuthorizationContext.Provider value={value}>{children}</AuthorizationContext.Provider>;


### PR DESCRIPTION
## Summary
- avoid RPC calls before authentication loads by checking auth loading state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17ac0caa4832ab89ab2ebd4766ddd