### PR TITLE
Restrict signup to investor role

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -75,6 +75,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
   };
 
   const preserve = scope ? `?scope=${encodeURIComponent(scope)}` : '';
+  const showSignup = !scope || scope === 'investidor';
 
     // Credenciais de teste para desenvolvimento
     const quickCredentials = allowedPanels
@@ -181,7 +182,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
         </div>
 
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-sm">
-          <a href={`/signup${preserve}`} className="story-link">Criar conta</a>
+          {showSignup && <a href={`/signup${preserve}`} className="story-link">Criar conta</a>}
           <a href={`/reset${preserve}`} className="story-link">Esqueci minha senha</a>
         </div>
 

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -15,15 +15,19 @@ export function SignupForm({ title, scope }: SignupFormProps) {
   const { register, handleSubmit } = useForm<{ name: string; email: string; password: string; confirm: string; terms: boolean }>();
   const [agreeError, setAgreeError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [ok, setOk] = useState<string | null>(null);
 
   const navigate = useNavigate();
 
   const onSubmit = handleSubmit(async (data) => {
-    setError(null); setOk(null);
+    setAgreeError(null);
+    setError(null);
     if (!data.terms) { setAgreeError('Você deve aceitar os Termos para continuar.'); return; }
     if (data.password !== data.confirm) { setError('As senhas não coincidem.'); return; }
-    const { error } = await supabase.auth.signUp({ email: data.email, password: data.password, options: { data: { full_name: data.name } } });
+    const { error } = await supabase.auth.signUp({
+      email: data.email,
+      password: data.password,
+      options: { data: { full_name: data.name, role: 'investidor' } }
+    });
     if (error) { setError(error.message || 'Falha ao criar conta'); return; }
     const qs = new URLSearchParams();
     if (scope) qs.set('scope', scope);
@@ -66,7 +70,6 @@ export function SignupForm({ title, scope }: SignupFormProps) {
       <Button type="submit" variant="cta" size="lg" className="w-full btn-glow active:scale-[0.99]">Criar conta</Button>
 
       {error && <p className="text-sm text-destructive" role="alert" aria-live="assertive">{error}</p>}
-      {ok && <p className="text-sm text-primary" role="status" aria-live="polite">{ok}</p>}
 
       <div className="flex items-center justify-between text-sm">
         <span className="text-muted-foreground">Já tem conta?</span>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,14 +1,12 @@
 import { useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
 import AuthLayout from "@/components/auth/AuthLayout";
 import { SignupForm } from "@/components/auth/SignupForm";
 import { labelFromScope } from "@/config/authConfig";
 
 export default function SignupPage() {
-  const [params] = useSearchParams();
-  const scope = params.get('scope') ?? 'investidor';
+  const scope = 'investidor';
   const label = labelFromScope(scope);
-  const title = label ? `Criar conta — ${label}` : 'Criar conta';
+  const title = `Criar conta — ${label}`;
 
   useEffect(() => {
     document.title = `${title} | BlockURB`;


### PR DESCRIPTION
## Summary
- enforce investor-only signups
- reset signup terms error and remove unused success state
- hide sign-up link on non-investor login pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17a42dd28832ab72717d16d7ea66e