### PR TITLE
Set search_path for handle_new_user in NovoSetup

### DIFF
--- a/NovoSetup/sql/migrations/20250816120000_user_profile_trigger.sql
+++ b/NovoSetup/sql/migrations/20250816120000_user_profile_trigger.sql
@@ -3,6 +3,7 @@ create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
 security definer
+set search_path = public
 as $$
 begin
   insert into public.user_profiles (user_id, email, full_name, role)

--- a/NovoSetup/sql/sql.final.referenciado.sql
+++ b/NovoSetup/sql/sql.final.referenciado.sql
@@ -65,6 +65,7 @@ create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
 security definer
+set search_path = public
 as $$
 begin
   insert into public.user_profiles (user_id, email, full_name, role)

--- a/NovoSetup/sql/sqlsemreferencia.sql
+++ b/NovoSetup/sql/sqlsemreferencia.sql
@@ -26,13 +26,14 @@ create table user_profiles (
 );
 
 -- Trigger para preencher user_profiles ao registrar um novo usuário
-create or replace function handle_new_user()
+create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
 security definer
+set search_path = public
 as $$
 begin
-  insert into user_profiles (user_id, email, full_name, role)
+  insert into public.user_profiles (user_id, email, full_name, role)
   values (new.id, new.email, coalesce(new.raw_user_meta_data->>'full_name', ''), 'investidor');
   return new;
 end;
@@ -40,7 +41,7 @@ $$;
 
 create trigger on_auth_user_created
 after insert on auth.users
-for each row execute function handle_new_user();
+for each row execute function public.handle_new_user();
 
 create table filial_allowed_panels (
     filial_id uuid references filiais(id) on delete cascade,


### PR DESCRIPTION
## Summary
- define search_path=public in handle_new_user function
- keep trigger pointing to public.handle_new_user

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17e30a14c832aa072b97e4f53ff1f