### PR TITLE
fix: qualify user_id in get_my_profile

### DIFF
--- a/NovoSetup/sql/sql.final.referenciado.sql
+++ b/NovoSetup/sql/sql.final.referenciado.sql
@@ -380,11 +380,16 @@ security definer
 as $$
 begin
   return query
-  select user_id, email, full_name, role,
-         to_jsonb(panels) as panels,
-         is_active, filial_id, updated_at
-  from public.user_profiles
-  where user_id = auth.uid();
+  select up.user_id,
+         up.email,
+         up.full_name,
+         up.role,
+         to_jsonb(up.panels) as panels,
+         up.is_active,
+         up.filial_id,
+         up.updated_at
+  from public.user_profiles up
+  where up.user_id = auth.uid();
 end;
 $$;
 

--- a/NovoSetup/sql/sqlsemreferencia.sql
+++ b/NovoSetup/sql/sqlsemreferencia.sql
@@ -117,11 +117,16 @@ security definer
 as $$
 begin
   return query
-  select user_id, email, full_name, role,
-         to_jsonb(panels) as panels,
-         is_active, filial_id, created_at
-  from user_profiles
-  where user_id = auth.uid();
+  select up.user_id,
+         up.email,
+         up.full_name,
+         up.role,
+         to_jsonb(up.panels) as panels,
+         up.is_active,
+         up.filial_id,
+         up.created_at
+  from user_profiles up
+  where up.user_id = auth.uid();
 end;
 $$;
 


### PR DESCRIPTION
## Summary
- avoid ambiguous user_id in get_my_profile
- ensure user profile RPC uses table aliases

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a188b61cc4832abf17f85cc66a4803