### PR TITLE
feat: add superadmin audit and reports dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import AdminsFiliaisPage from "./pages/admin/AdminsFiliais";
 import AcessoNegado from "./pages/AcessoNegado";
 import { Protected } from "@/components/Protected";
 import MapaSuperAdmin from "./pages/admin/MapaSuperAdmin";
+import AuditLogsPage from "./pages/admin/AuditLogs";
+import ReportsDashboard from "./pages/admin/ReportsDashboard";
 
 const queryClient = new QueryClient();
 
@@ -65,7 +67,8 @@ const App = () => (
 <Route path="/super-admin/clientes-saas" element={<Protected allowedRoles={['superadmin']}><ClientesSaasPage /></Protected>} />
             <Route path="/super-admin/filiais-acessos" element={<Protected allowedRoles={['superadmin']}><FiliaisAccessPage /></Protected>} />
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
-            <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Relatórios" /></Protected>} />
+            <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
+            <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Configurações" /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -20,6 +20,7 @@ export const NAV: Record<string, NavItem[]> = {
     { label: "Usuários", href: "/super-admin/usuarios", icon: "user" },
     { label: "Aprovação", href: "/super-admin/aprovacao", icon: "check-circle" },
     { label: "Tokenização", href: "/super-admin/tokenizacao", icon: "key" },
+    { label: "Auditoria", href: "/super-admin/auditoria", icon: "file-text" },
 
     { label: "Relatórios", href: "/super-admin/relatorios", icon: "bar-chart-2" },
     { label: "Configurações", href: "/super-admin/config", icon: "settings" },

--- a/src/pages/admin/AuditLogs.tsx
+++ b/src/pages/admin/AuditLogs.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+type AuditLog = {
+  id: string;
+  actor: string;
+  action: string;
+  target: string | null;
+  metadata: any;
+  created_at: string;
+};
+
+const PAGE_SIZE = 20;
+
+export default function AuditLogsPage() {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [userFilter, setUserFilter] = useState("");
+  const [filialFilter, setFilialFilter] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  useEffect(() => {
+    document.title = "Auditoria | BlockURB";
+  }, []);
+
+  const loadLogs = useCallback(async () => {
+    setLoading(true);
+    let query = supabase
+      .from("audit_logs")
+      .select("*", { count: "exact" })
+      .order("created_at", { ascending: false })
+      .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1);
+    if (userFilter.trim()) {
+      query = query.eq("actor", userFilter.trim());
+    }
+    if (filialFilter.trim()) {
+      query = query.contains("metadata", { filial_id: filialFilter.trim() });
+    }
+    if (actionFilter.trim()) {
+      query = query.eq("action", actionFilter.trim());
+    }
+    if (startDate) {
+      query = query.gte("created_at", startDate);
+    }
+    if (endDate) {
+      query = query.lte("created_at", endDate);
+    }
+    const { data, count } = await query;
+    setLogs((data as any) || []);
+    setTotal(count || 0);
+    setLoading(false);
+  }, [page, userFilter, filialFilter, actionFilter, startDate, endDate]);
+
+  useEffect(() => {
+    void loadLogs();
+  }, [loadLogs]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [userFilter, filialFilter, actionFilter, startDate, endDate]);
+
+  const exportCsv = () => {
+    const header = ["id", "actor", "action", "target", "filial_id", "created_at"];
+    const rows = logs.map((l) => [l.id, l.actor, l.action, l.target ?? "", l.metadata?.filial_id ?? "", l.created_at]);
+    const csv = [header.join(","), ...rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(","))].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "audit_logs.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: "Super Admin" }, { label: "Auditoria" }]}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Auditoria de Ações</CardTitle>
+            <CardDescription>Histórico de operações realizadas na plataforma.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+              <div>
+                <label className="text-sm text-muted-foreground">Usuário (ID)</label>
+                <Input value={userFilter} onChange={e => setUserFilter(e.target.value)} placeholder="ID do usuário" />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">Filial</label>
+                <Input value={filialFilter} onChange={e => setFilialFilter(e.target.value)} placeholder="ID da filial" />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">Ação</label>
+                <Input value={actionFilter} onChange={e => setActionFilter(e.target.value)} placeholder="Tipo de ação" />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">De</label>
+                <Input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">Até</label>
+                <Input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+              </div>
+            </div>
+            <div className="flex justify-between items-center">
+              <Button variant="secondary" onClick={() => { setUserFilter(""); setFilialFilter(""); setActionFilter(""); setStartDate(""); setEndDate(""); }}>Limpar filtros</Button>
+              <Button onClick={exportCsv}>Exportar CSV</Button>
+            </div>
+            {loading ? (
+              <p className="text-center text-muted-foreground">Carregando...</p>
+            ) : (
+              <div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Data</TableHead>
+                      <TableHead>Usuário</TableHead>
+                      <TableHead>Ação</TableHead>
+                      <TableHead>Alvo</TableHead>
+                      <TableHead>Filial</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {logs.map((log) => (
+                      <TableRow key={log.id}>
+                        <TableCell>{new Date(log.created_at).toLocaleString()}</TableCell>
+                        <TableCell className="font-mono">{log.actor}</TableCell>
+                        <TableCell>{log.action}</TableCell>
+                        <TableCell className="font-mono">{log.target ?? "—"}</TableCell>
+                        <TableCell className="font-mono">{log.metadata?.filial_id ?? "—"}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <div className="flex justify-between items-center pt-2 text-sm">
+                  <span>Página {page + 1} de {totalPages}</span>
+                  <div className="flex gap-2">
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}>Anterior</Button>
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))} disabled={page >= totalPages - 1}>Próxima</Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/src/pages/admin/ReportsDashboard.tsx
+++ b/src/pages/admin/ReportsDashboard.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+type ReportRow = {
+  filial_id: string;
+  empreendimentos: number;
+  usuarios: number;
+  lotes_vendidos: number;
+  ocupacao: number;
+};
+
+export default function ReportsDashboard() {
+  const [rows, setRows] = useState<ReportRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filial, setFilial] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  useEffect(() => {
+    document.title = "Relatórios Operacionais | BlockURB";
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const { data } = await supabase.rpc("superadmin_reports", {
+      filial_id: filial || null,
+      from_date: from || null,
+      to_date: to || null,
+    });
+    setRows((data as any) || []);
+    setLoading(false);
+  }, [filial, from, to]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const exportCsv = () => {
+    const header = ["filial_id", "empreendimentos", "usuarios", "lotes_vendidos", "ocupacao"];
+    const csv = [
+      header.join(","),
+      ...rows.map(r => [r.filial_id, r.empreendimentos, r.usuarios, r.lotes_vendidos, r.ocupacao].join(",")),
+    ].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "relatorios.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: "Super Admin" }, { label: "Relatórios" }]}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Relatórios Operacionais</CardTitle>
+            <CardDescription>Métricas agregadas por filial.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+              <div>
+                <label className="text-sm text-muted-foreground">Filial</label>
+                <Input value={filial} onChange={e => setFilial(e.target.value)} placeholder="ID da filial" />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">De</label>
+                <Input type="date" value={from} onChange={e => setFrom(e.target.value)} />
+              </div>
+              <div>
+                <label className="text-sm text-muted-foreground">Até</label>
+                <Input type="date" value={to} onChange={e => setTo(e.target.value)} />
+              </div>
+              <div className="flex items-end gap-2">
+                <Button onClick={load} disabled={loading}>Aplicar</Button>
+                <Button variant="secondary" onClick={() => { setFilial(""); setFrom(""); setTo(""); void load(); }}>Limpar</Button>
+              </div>
+            </div>
+            {loading ? (
+              <p className="text-center text-muted-foreground">Carregando...</p>
+            ) : (
+              <div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Filial</TableHead>
+                      <TableHead>Empreendimentos</TableHead>
+                      <TableHead>Usuários</TableHead>
+                      <TableHead>Lotes vendidos</TableHead>
+                      <TableHead>Ocupação (%)</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map(r => (
+                      <TableRow key={r.filial_id}>
+                        <TableCell className="font-mono">{r.filial_id}</TableCell>
+                        <TableCell>{r.empreendimentos}</TableCell>
+                        <TableCell>{r.usuarios}</TableCell>
+                        <TableCell>{r.lotes_vendidos}</TableCell>
+                        <TableCell>{r.ocupacao}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <div className="flex justify-end pt-2">
+                  <Button onClick={exportCsv}>Exportar CSV</Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </AppShell>
+    </Protected>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add superadmin Audit Logs page with filtering, pagination and CSV export
- add operational reports dashboard for superadmins with filial and date filters plus CSV export
- wire up navigation and routing for new dashboards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19c2e7524832a8acb74af8a09abe6