### PR TITLE
refactor: extract auth hooks from providers

### DIFF
--- a/src/components/Protected.tsx
+++ b/src/components/Protected.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { useAuth } from "@/providers/AuthProvider";
-import { useAuthorization } from "@/providers/AuthorizationProvider";
+import { useAuth } from "@/hooks/useAuth";
+import { useAuthorization } from "@/hooks/useAuthorization";
 
 interface ProtectedProps {
   children: React.ReactNode;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -98,7 +98,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbP
 import { Bell, Search, User as UserIcon, LogOut } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { useAuth } from "@/providers/AuthProvider";
+import { useAuth } from "@/hooks/useAuth";
 
 export function AppShell({ breadcrumbs = [], children }: AppShellProps) {
   const { user } = useAuth();

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
 import { NAV, inferMenuKey } from "@/config/nav";
-import { useAuthorization } from "@/providers/AuthorizationProvider";
+import { useAuthorization } from "@/hooks/useAuthorization";
 import type { LucideIcon } from "lucide-react";
 import {
   Layout,

--- a/src/components/shell/Topbar.tsx
+++ b/src/components/shell/Topbar.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { useAuth } from "@/providers/AuthProvider";
+import { useAuth } from "@/hooks/useAuth";
 import { Bell, Search, User as UserIcon, LogOut } from "lucide-react";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { AuthContext } from '@/providers/AuthProvider';
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/hooks/useAuthorization.ts
+++ b/src/hooks/useAuthorization.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { AuthorizationContext } from '@/providers/AuthorizationProvider';
+
+export function useAuthorization() {
+  return useContext(AuthorizationContext);
+}

--- a/src/pages/AcessoNegado.tsx
+++ b/src/pages/AcessoNegado.tsx
@@ -1,7 +1,7 @@
 import { ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
-import { useAuthorization } from "@/providers/AuthorizationProvider";
+import { useAuthorization } from "@/hooks/useAuthorization";
 import { supabase } from "@/lib/dataClient";
 import { useEffect } from "react";
 

--- a/src/pages/admin/EmpreendimentoNovo.tsx
+++ b/src/pages/admin/EmpreendimentoNovo.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { supabase } from "@/lib/dataClient";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
-import { useAuthorization } from "@/providers/AuthorizationProvider";
+import { useAuthorization } from "@/hooks/useAuthorization";
 import { processGeoJSON, LoteData } from "@/lib/geojsonUtils";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";

--- a/src/pages/admin/Mapa.tsx
+++ b/src/pages/admin/Mapa.tsx
@@ -14,7 +14,7 @@ import L, { LatLngBoundsExpression, Layer } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import { toast } from "sonner";
 import { LoteInfoModal, LoteDetalhado } from "@/components/LoteInfoModal";
-import { useAuthorization } from "@/providers/AuthorizationProvider";
+import { useAuthorization } from "@/hooks/useAuthorization";
 
 // --- INÍCIO DA VERSÃO ESTÁVEL E CORRIGIDA ---
 

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/lib/dataClient';
 import type { Session, User } from '@supabase/supabase-js';
 
@@ -8,7 +8,7 @@ interface AuthState {
   loading: boolean;
 }
 
-const AuthContext = createContext<AuthState>({ session: null, user: null, loading: true });
+export const AuthContext = createContext<AuthState>({ session: null, user: null, loading: true });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
@@ -40,8 +40,3 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo(() => ({ session, user, loading }), [session, user, loading]);
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
-
-export function useAuth() {
-  return useContext(AuthContext);
-}
-

--- a/src/providers/AuthorizationProvider.tsx
+++ b/src/providers/AuthorizationProvider.tsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/lib/dataClient';
-import { useAuth } from './AuthProvider';
+import { useAuth } from '@/hooks/useAuth';
 
 export interface AuthorizationProfile {
   role: string;
@@ -13,7 +13,7 @@ interface AuthorizationState {
   loading: boolean;
 }
 
-const AuthorizationContext = createContext<AuthorizationState>({ profile: null, loading: true });
+export const AuthorizationContext = createContext<AuthorizationState>({ profile: null, loading: true });
 
 export function AuthorizationProvider({ children }: { children: React.ReactNode }) {
   const { user, loading: authLoading } = useAuth();
@@ -88,8 +88,3 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
   const value = useMemo(() => ({ profile, loading }), [profile, loading]);
   return <AuthorizationContext.Provider value={value}>{children}</AuthorizationContext.Provider>;
 }
-
-export function useAuthorization() {
-  return useContext(AuthorizationContext);
-}
-


### PR DESCRIPTION
## Summary
- move auth and authorization hooks into dedicated `src/hooks` files
- expose only context and provider from auth-related providers
- update imports to use new hooks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a57687b0832a9f12cf4b5a178282