### PR TITLE
Add Super Admin routes for dashboard, filiais, and real map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,9 @@ import { Protected } from "@/components/Protected";
 import MapaSuperAdmin from "./pages/admin/MapaSuperAdmin";
 import AuditLogsPage from "./pages/admin/AuditLogs";
 import ReportsDashboard from "./pages/admin/ReportsDashboard";
+import AdminDashboard from "./pages/AdminDashboard";
+import FiliaisPage from "./pages/admin/Filiais";
+import MapaRealPage from "./pages/admin/MapaReal";
 
 const queryClient = new QueryClient();
 
@@ -62,6 +65,9 @@ const App = () => (
             {/* Panels - ROTAS PROTEGIDAS */}
             {/* Super Admin */}
             <Route path="/super-admin" element={<Protected allowedRoles={['superadmin']}><PanelHomePage menuKey="superadmin" title="Super Admin" /></Protected>} />
+            <Route path="/super-admin/dashboard" element={<Protected allowedRoles={['superadmin']}><AdminDashboard /></Protected>} />
+            <Route path="/super-admin/filiais" element={<Protected allowedRoles={['superadmin']}><FiliaisPage /></Protected>} />
+            <Route path="/super-admin/mapa-real" element={<Protected allowedRoles={['superadmin']}><MapaRealPage /></Protected>} />
             <Route path="/super-admin/admins-filiais" element={<Protected allowedRoles={['superadmin']}><AdminsFiliaisPage /></Protected>} />
             <Route path="/super-admin/filiais-internas" element={<Protected allowedRoles={['superadmin']}><FiliaisInternasPage /></Protected>} />
 <Route path="/super-admin/clientes-saas" element={<Protected allowedRoles={['superadmin']}><ClientesSaasPage /></Protected>} />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -4,10 +4,12 @@ export const NAV: Record<string, NavItem[]> = {
   superadmin: [
     {
       title: 'Dashboard',
-      href: '/super-admin',
+      href: '/super-admin/dashboard',
       icon: 'layout-dashboard'
     },
     { label: "Mapa Interativo", href: "/super-admin/mapa", icon: "map" },
+    { label: "Mapa Real", href: "/super-admin/mapa-real", icon: "map-pin" },
+    { label: 'Gestão de Filiais', href: '/super-admin/filiais', icon: 'building' },
     { label: 'Filiais Internas Cadastradas', href: '/super-admin/filiais-internas', icon: 'building' },
     { label: 'Gestão SaaS', href: '/super-admin/clientes-saas', icon: 'users' },
     { label: "Acessos por Filial", href: "/super-admin/filiais-acessos", icon: "shield" },

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { AppShell } from "@/components/layout/AppShell";
+import { AppShell } from "@/components/shell/AppShell";
 import { Protected } from "@/components/Protected";
 import { KPIStat } from "@/components/app/KPIStat";
 import { FiltersBar } from "@/components/app/FiltersBar";
@@ -35,7 +35,7 @@ export default function AdminDashboard() {
 
   return (
     <Protected debugBypass={true}>
-      <AppShell breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin', href: '/admin' }, { label: 'Dashboard' }]}> 
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: 'Super Admin', href: '/super-admin' }, { label: 'Dashboard' }]}> 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <KPIStat label="Lotes disponíveis" value={128} icon={<Building2 className="text-primary" />} />
           <KPIStat label="Reservas pendentes" value={12} icon={<FileText className="text-accent" />} tone="warning" />

--- a/src/pages/admin/Filiais.tsx
+++ b/src/pages/admin/Filiais.tsx
@@ -226,7 +226,7 @@ export default function FiliaisPage({ filter }: { filter?: "interna" | "saas" })
 
   return (
     <Protected allowedRoles={["superadmin"]}>
-      <AppShell menuKey="superadmin" breadcrumbs={[{ label: 'Admin' }, { label: 'Gestão de Filiais' }]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: 'Super Admin', href: '/super-admin' }, { label: 'Gestão de Filiais' }]}> 
         <div className="grid gap-6 md:grid-cols-2">
           {/* Coluna da Esquerda: Adicionar Nova Filial */}
           <div className="space-y-6">

--- a/src/pages/admin/MapaReal.tsx
+++ b/src/pages/admin/MapaReal.tsx
@@ -312,11 +312,11 @@ function MapView({ selected }: { selected?: Empreendimento }) {
 
 export default function AdminMapaReal() {
   const [active, setActive] = useState<Empreendimento | undefined>(undefined);
-  useEffect(() => { document.title = "Mapa Interativo (Real) | BlockURB"; }, []);
+  useEffect(() => { document.title = "Mapa Real | BlockURB"; }, []);
 
   return (
-    <Protected>
-      <AppShell menuKey="adminfilial" breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Admin' }, { label: 'Mapa Interativo (Real)' }]}> 
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: 'Super Admin', href: '/super-admin' }, { label: 'Mapa Real' }]}> 
         <div className="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)] items-start">
           <div className="h-full">
             <SidebarEmpreendimentos onSelect={setActive} activeId={active?.id} />


### PR DESCRIPTION
## Summary
- expose legacy AdminDashboard, Filiais management and Real Map pages in Super Admin panel
- highlight Super Admin navigation entries for Dashboard, Filiais and Real Map
- align pages' breadcrumbs and permissions with Super Admin scope

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2447e476c832a930a20ed983486b5