### PR TITLE
feat: add impersonation support for admins

### DIFF
--- a/NovoSetup/sql/migrations/20250816140000_impersonate_user.sql
+++ b/NovoSetup/sql/migrations/20250816140000_impersonate_user.sql
@@ -1,0 +1,28 @@
+-- Function to impersonate users
+create or replace function impersonate_user(p_user_id uuid)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_role text;
+  v_access_token text;
+  v_refresh_token text;
+begin
+  select role into v_role from user_profiles where user_id = auth.uid();
+  if v_role <> 'superadmin' then
+    raise exception 'Acesso negado';
+  end if;
+
+  v_access_token := auth.sign_jwt(json_build_object('sub', p_user_id, 'role', 'authenticated'));
+  v_refresh_token := auth.sign_jwt(json_build_object('sub', p_user_id, 'role', 'authenticated', 'type', 'refresh'));
+
+  insert into audit_logs(actor, action, target)
+  values (auth.uid(), 'impersonate_user', p_user_id::text);
+
+  return json_build_object('access_token', v_access_token, 'refresh_token', v_refresh_token);
+end;
+$$;
+
+grant execute on function impersonate_user(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- enable session overrides in AuthProvider for impersonation
- add impersonate_user RPC with audit log
- allow super admins to impersonate users from admin table

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a24d8f5a18832ab612f59adf068311