### PR TITLE
feat: add admin settings page and RPCs

### DIFF
--- a/NovoSetup/sql/migrations/20250816140000_app_settings.sql
+++ b/NovoSetup/sql/migrations/20250816140000_app_settings.sql
@@ -1,0 +1,54 @@
+-- Tabela de configurações de aplicação e RPCs de acesso
+create table if not exists app_settings (
+  key text primary key,
+  value text not null
+);
+
+alter table app_settings enable row level security;
+create policy "select_app_settings_superadmin" on app_settings
+for select using (
+  exists (select 1 from user_profiles up where up.user_id = auth.uid() and up.role = 'superadmin')
+);
+
+create or replace function admin_get_setting(p_key text)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_role text;
+  v_value text;
+begin
+  select role into v_role from user_profiles where user_id = auth.uid();
+  if v_role <> 'superadmin' then
+    raise exception 'Acesso negado';
+  end if;
+
+  select value into v_value from app_settings where key = p_key;
+  return v_value;
+end;
+$$;
+
+create or replace function admin_set_setting(p_key text, p_value text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_role text;
+begin
+  select role into v_role from user_profiles where user_id = auth.uid();
+  if v_role <> 'superadmin' then
+    raise exception 'Acesso negado';
+  end if;
+
+  insert into app_settings(key, value)
+  values (p_key, p_value)
+  on conflict(key) do update set value = excluded.value;
+
+  insert into audit_logs(actor, action, target, metadata)
+  values (auth.uid(), 'set_setting', p_key, jsonb_build_object('value', p_value));
+end;
+$$;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Reset from "./pages/Reset";
 import { AuthProvider } from "@/providers/AuthProvider";
 import { AuthorizationProvider } from "@/providers/AuthorizationProvider";
 import { PanelHomePage, PanelSectionPage } from "@/components/panels/PanelPages";
+import ConfigPage from "./pages/admin/Config";
 import EmpreendimentoNovo from "./pages/admin/EmpreendimentoNovo";
 import AdminMapa from "./pages/admin/Mapa";
 import MapaInterativo from "./pages/admin/MapaInterativo";
@@ -75,7 +76,7 @@ const App = () => (
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
-            <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Configurações" /></Protected>} />
+            <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />
             <Route path="/super-admin/tokenizacao" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Tokenização" /></Protected>} />

--- a/src/pages/admin/Config.tsx
+++ b/src/pages/admin/Config.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { toast } from "sonner";
+
+export default function ConfigPage() {
+  const [maxFiliais, setMaxFiliais] = useState("0");
+  const [enableNewFeature, setEnableNewFeature] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    document.title = "Configurações | BlockURB";
+  }, []);
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      const { data: maxData } = await supabase.rpc("admin_get_setting", { p_key: "max_filiais" });
+      if (maxData) setMaxFiliais(String(maxData));
+      const { data: featureData } = await supabase.rpc("admin_get_setting", { p_key: "enable_new_feature" });
+      if (featureData) setEnableNewFeature(featureData === "true");
+    };
+    void loadSettings();
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const { error: err1 } = await supabase.rpc("admin_set_setting", { p_key: "max_filiais", p_value: maxFiliais });
+      if (err1) throw err1;
+      const { error: err2 } = await supabase.rpc("admin_set_setting", { p_key: "enable_new_feature", p_value: enableNewFeature ? "true" : "false" });
+      if (err2) throw err2;
+      toast.success("Configurações salvas");
+    } catch (e: any) {
+      toast.error(e?.message || "Falha ao salvar");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: "Super Admin" }, { label: "Configurações" }]}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Configurações Gerais</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <Label htmlFor="max_filiais">Limite de Filiais</Label>
+              <Input id="max_filiais" type="number" value={maxFiliais} onChange={e => setMaxFiliais(e.target.value)} />
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch id="enable_new_feature" checked={enableNewFeature} onCheckedChange={setEnableNewFeature} />
+              <Label htmlFor="enable_new_feature">Habilitar novo recurso</Label>
+            </div>
+            <Button onClick={save} disabled={saving}>Salvar</Button>
+          </CardContent>
+        </Card>
+      </AppShell>
+    </Protected>
+  );
+}


### PR DESCRIPTION
## Summary
- add super admin configuration page with critical parameters
- define `app_settings` table and `admin_get_setting`/`admin_set_setting` RPCs with audit logging
- update routing to use new configuration page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a24d9626cc832ab0dfa1d04ac969d4