### PR TITLE
Fix user list rendering on super admin users page

### DIFF
--- a/src/pages/admin/Usuarios.tsx
+++ b/src/pages/admin/Usuarios.tsx
@@ -45,10 +45,6 @@ export default function UsuariosPage() {
   }, []);
 
   useEffect(() => {
-    void loadUsers();
-  }, [loadUsers]);
-
-  useEffect(() => {
     setPage(0);
   }, [search, roleFilter]);
 
@@ -80,6 +76,10 @@ export default function UsuariosPage() {
     setTotal(count || 0);
     setLoading(false);
   }, [page, roleFilter, search]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
 
   const updateRole = async (userId: string, newRole: string) => {
     const normalized: string | null = newRole === "no-role" ? null : newRole;


### PR DESCRIPTION
## Summary
- Move user-loading effect after `loadUsers` function to prevent reference error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a252dde5a8832a8a7384a33d24e641