### PR TITLE
Share selected empreendimento across panels

### DIFF
--- a/src/hooks/useSelectedEmpreendimento.tsx
+++ b/src/hooks/useSelectedEmpreendimento.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface SelectedEmpreendimentoContextType {
+  selectedEmpreendimento: string | null;
+  setSelectedEmpreendimento: (id: string | null) => void;
+}
+
+const SelectedEmpreendimentoContext = createContext<SelectedEmpreendimentoContextType | undefined>(undefined);
+
+export function SelectedEmpreendimentoProvider({ children }: { children: ReactNode }) {
+  const [selectedEmpreendimento, setSelectedEmpreendimentoState] = useState<string | null>(() => {
+    return typeof localStorage !== 'undefined' ? localStorage.getItem('selectedEmpreendimento') : null;
+  });
+
+  function setSelectedEmpreendimento(id: string | null) {
+    setSelectedEmpreendimentoState(id);
+    if (typeof localStorage === 'undefined') return;
+    if (id) localStorage.setItem('selectedEmpreendimento', id);
+    else localStorage.removeItem('selectedEmpreendimento');
+  }
+
+  return (
+    <SelectedEmpreendimentoContext.Provider value={{ selectedEmpreendimento, setSelectedEmpreendimento }}>
+      {children}
+    </SelectedEmpreendimentoContext.Provider>
+  );
+}
+
+export function useSelectedEmpreendimento() {
+  const context = useContext(SelectedEmpreendimentoContext);
+  if (!context) throw new Error('useSelectedEmpreendimento must be used within SelectedEmpreendimentoProvider');
+  return context;
+}


### PR DESCRIPTION
## Summary
- add context hook to store selected empreendimento across pages
- load supabase data tables in panel pages filtered by active empreendimento

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25cae6cfc832abeab0e51db3becff