### PR TITLE
feat: add recharts dashboards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ const App = () => (
             <Route path="/super-admin/filiais-acessos" element={<Protected allowedRoles={['superadmin']}><FiliaisAccessPage /></Protected>} />
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
-            <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
+            <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard menuKey="superadmin" title="Super Admin" rpcFn="superadmin_reports" allowedRoles={['superadmin']} /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />
@@ -83,7 +83,7 @@ const App = () => (
 
             {/* Admin Filial - Rotas padronizadas em /admin-filial */}
             <Route path="/admin-filial" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelHomePage menuKey="adminfilial" title="Admin Filial" /></Protected>} />
-            <Route path="/admin-filial/relatorios" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Relatórios" /></Protected>} />
+            <Route path="/admin-filial/relatorios" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><ReportsDashboard menuKey="adminfilial" title="Admin Filial" rpcFn="adminfilial_reports" allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial" /></Protected>} />
             <Route path="/admin-filial/config" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Configurações" /></Protected>} />
             <Route path="/admin-filial/equipe" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Equipe" /></Protected>} />
             <Route path="/admin-filial/empreendimentos" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Empreendimentos" /></Protected>} />

--- a/src/components/app/PanelReportsChart.tsx
+++ b/src/components/app/PanelReportsChart.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+interface Point {
+  day: string;
+  value: number;
+}
+
+export function PanelReportsChart() {
+  const [data, setData] = useState<Point[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.rpc("superadmin_reports", {
+        filial_ids: null,
+        from_date: null,
+        to_date: null,
+      });
+      const mapped = (data as any[])?.map(r => ({ day: r.day, value: r.lotes_vendidos })) ?? [];
+      setData(mapped);
+    };
+    void load();
+  }, []);
+
+  return (
+    <div className="rounded-[14px] border border-border bg-secondary/60 p-4">
+      <h3 className="font-semibold">Lotes vendidos</h3>
+      <div className="mt-4 h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="day" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="value" stroke="var(--primary)" strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export default PanelReportsChart;

--- a/src/components/panels/PanelPages.tsx
+++ b/src/components/panels/PanelPages.tsx
@@ -3,7 +3,7 @@ import { AppShell } from "@/components/shell/AppShell";
 import { KPIStat } from "@/components/app/KPIStat";
 import { FiltersBar } from "@/components/app/FiltersBar";
 import { DataTable } from "@/components/app/DataTable";
-import { ChartPlaceholder } from "@/components/app/ChartPlaceholder";
+import { PanelReportsChart } from "@/components/app/PanelReportsChart";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Building2, FileText, Target, Plus, Wrench } from "lucide-react";
@@ -83,7 +83,7 @@ export function PanelHomePage({ menuKey, title }: { menuKey: string; title: stri
               <DataTable columns={adminTeamColumns} rows={adminTeamRows} pageSize={5} />
             </div>
             <div>
-              <ChartPlaceholder title="Gráfico (placeholder)" />
+              <PanelReportsChart />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add reusable reports dashboard with line, bar and pie charts powered by Supabase
- wire admin-filial reports route to dashboard
- replace panel placeholder with Recharts chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25cb1a018832a816eb78b79076374