### PR TITLE
Corrige filtro de painéis no login rápido

### DIFF
--- a/src/components/QuickLoginWidget.test.ts
+++ b/src/components/QuickLoginWidget.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { QuickLoginCredential } from '@/config/quickLogin';
+import { filterQuickLoginCredentials } from '@/lib/quickLogin';
+
+vi.mock('@/config/quickLogin', () => {
+  const mockCreds: QuickLoginCredential[] = [
+    { email: 'a@a.com', password: 'pass', label: 'A', role: 'role1', panel: '/panel1', icon: () => null },
+    { email: 'b@b.com', password: 'pass', label: 'B', role: 'role2', panel: '/panel2', icon: () => null }
+  ];
+  return { quickLoginCredentials: mockCreds };
+});
+
+describe('filterQuickLoginCredentials', () => {
+  it('filters credentials by allowed panels', () => {
+    const result = filterQuickLoginCredentials(['/panel2']);
+    expect(result).toHaveLength(1);
+    expect(result[0].panel).toBe('/panel2');
+  });
+
+  it('returns all credentials when allowedPanels is undefined', () => {
+    const result = filterQuickLoginCredentials();
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -5,7 +5,8 @@ import { Settings, Zap } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { quickLoginCredentials, type QuickLoginCredential } from "@/config/quickLogin";
+import type { QuickLoginCredential } from "@/config/quickLogin";
+import { filterQuickLoginCredentials } from "@/lib/quickLogin";
 
 interface QuickLoginWidgetProps {
   compact?: boolean;
@@ -23,9 +24,7 @@ export function QuickLoginWidget({ compact = false, className = "", allowedPanel
       return null;
     }
 
-    const creds = allowedPanels
-      ? quickLoginCredentials.filter((c) => allowedPanels.includes(c.role))
-      : quickLoginCredentials;
+    const creds = filterQuickLoginCredentials(allowedPanels);
 
     if (creds.length === 0) {
       return null;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -4,7 +4,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Eye, EyeOff } from "lucide-react";
-import { quickLoginCredentials } from "@/config/quickLogin";
+import { filterQuickLoginCredentials } from "@/lib/quickLogin";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/dataClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -78,9 +78,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
   const showSignup = !scope || scope === 'investidor';
 
     // Credenciais de teste para desenvolvimento
-    const quickCredentials = allowedPanels
-      ? quickLoginCredentials.filter((c) => allowedPanels.includes(c.role))
-      : quickLoginCredentials;
+    const quickCredentials = filterQuickLoginCredentials(allowedPanels);
 
   return (
     <div className="space-y-6">

--- a/src/lib/quickLogin.ts
+++ b/src/lib/quickLogin.ts
@@ -1,0 +1,7 @@
+import { quickLoginCredentials, type QuickLoginCredential } from '@/config/quickLogin';
+
+export function filterQuickLoginCredentials(allowedPanels?: string[]): QuickLoginCredential[] {
+  return allowedPanels
+    ? quickLoginCredentials.filter((c) => allowedPanels.includes(c.panel))
+    : quickLoginCredentials;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,13 +32,14 @@ export default function LoginPage() {
     useEffect(() => {
       const host = window.location.host;
       const mapPanelToScope = (p: string) => (p === 'adminfilial' ? 'admin' : p);
+      const mapPanelToPath = (p: string) => pathFromScope(mapPanelToScope(p));
       fetch(`/resolve-domain?domain=${host}`)
-        .then((res) => res.ok ? res.json() : null)
+        .then((res) => (res.ok ? res.json() : null))
         .then((data) => {
           if (data) {
             setBrand(data.nome || null);
             if (Array.isArray(data.panels)) {
-              setAllowedPanels(data.panels);
+              setAllowedPanels(data.panels.map(mapPanelToPath));
               if (!scopeParam && data.panels.length > 0) {
                 setDefaultScope(mapPanelToScope(data.panels[0]));
               }


### PR DESCRIPTION
## Summary
- Filtra credenciais rápidas usando o campo de painel
- Converte allowedPanels para caminhos de painel
- Adiciona teste unitário para o filtro de login rápido

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a266b79800832a8a5cfb47cd2c7d24