### PR TITLE
refactor: centralize lote status styles

### DIFF
--- a/docs/lote-status-styles.md
+++ b/docs/lote-status-styles.md
@@ -1,0 +1,8 @@
+# Mapa de status de lotes
+
+| Status      | Cor (hex) | Variant |
+|-------------|-----------|---------|
+| disponivel  | `#22c55e` | secondary |
+| reservado   | `#eab308` | default |
+| vendido     | `#ef4444` | destructive |
+| outro       | `#3b82f6` | outline |

--- a/src/components/LoteInfoModal.tsx
+++ b/src/components/LoteInfoModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { getStatusVariant } from "@/lib/loteStyles";
 
 // Interface para as propriedades detalhadas do lote
 export interface LoteDetalhado {
@@ -40,15 +41,6 @@ const formatCurrency = (num: number | null | undefined) => {
 
 export function LoteInfoModal({ lote, isOpen, onClose }: LoteInfoModalProps) {
   if (!lote) return null;
-
-  const getStatusVariant = (status: string) => {
-    switch (status) {
-        case 'disponivel': return 'default';
-        case 'vendido': return 'destructive';
-        case 'reservado': return 'secondary';
-        default: return 'outline';
-    }
-  }
 
   const numeroTexto = (() => {
     if (lote.numero !== null && lote.numero !== undefined) return String(lote.numero);

--- a/src/components/app/LotesMapPreview.tsx
+++ b/src/components/app/LotesMapPreview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { supabase } from '@/lib/dataClient';
+import { getLoteStatusStyle } from '@/lib/loteStyles';
 
 interface Props {
   empreendimentoId?: string;
@@ -41,14 +42,7 @@ export function LotesMapPreview({ empreendimentoId, height = '380px' }: Props) {
           layerRef.current = null;
         }
         const layer = L.geoJSON(data as any, {
-          style: (feature) => {
-            const status = feature?.properties?.status || 'disponivel';
-            switch (status) {
-              case 'reservado': return { color: '#EAB308', fillColor: '#EAB308', fillOpacity: 0.25, weight: 2 };
-              case 'vendido': return { color: '#EF4444', fillColor: '#EF4444', fillOpacity: 0.25, weight: 2 };
-              default: return { color: '#00C26E', fillColor: '#00C26E', fillOpacity: 0.25, weight: 2 };
-            }
-          }
+          style: (feature) => getLoteStatusStyle(feature?.properties?.status || 'disponivel')
         }).addTo(map);
         layerRef.current = layer;
         const bounds = layer.getBounds();

--- a/src/lib/geojsonUtils.ts
+++ b/src/lib/geojsonUtils.ts
@@ -174,37 +174,7 @@ export function processGeoJSON(geojsonText: string): ProcessedGeoJSON {
   }
 }
 
-/**
- * Gera cores para status dos lotes
- */
-export function getLoteColor(status: string): string {
-  switch (status) {
-    case 'disponivel':
-      return '#22c55e'; // Verde
-    case 'reservado':
-      return '#eab308'; // Amarelo
-    case 'vendido':
-      return '#ef4444'; // Vermelho
-    default:
-      return '#3b82f6'; // Azul (padrão)
-  }
-}
-
-/**
- * Gera opções de estilo para Leaflet baseado no status
- */
-export function getLoteStyle(status: string, isHovered: boolean = false, isSelected: boolean = false) {
-  const baseColor = getLoteColor(status);
-  
-  return {
-    color: isSelected ? '#1e40af' : baseColor,
-    weight: isSelected ? 3 : isHovered ? 2 : 1,
-    opacity: 1,
-    fillColor: baseColor,
-    fillOpacity: isHovered ? 0.7 : isSelected ? 0.8 : 0.5,
-    dashArray: status === 'reservado' ? '5, 5' : undefined
-  };
-}
+export { getLoteColor, getLoteStyle } from './loteStyles';
 
 /**
  * Formata área para exibição

--- a/src/lib/loteStyles.ts
+++ b/src/lib/loteStyles.ts
@@ -1,0 +1,34 @@
+export type LoteStatus = 'disponivel' | 'reservado' | 'vendido';
+
+export const STATUS_MAP: Record<LoteStatus, { color: string; variant: 'default' | 'secondary' | 'destructive' }> = {
+  disponivel: { color: '#22c55e', variant: 'secondary' },
+  reservado: { color: '#eab308', variant: 'default' },
+  vendido: { color: '#ef4444', variant: 'destructive' },
+};
+
+const DEFAULT_STYLE = { color: '#3b82f6', variant: 'outline' as const };
+
+export function getLoteColor(status: string): string {
+  return STATUS_MAP[status as LoteStatus]?.color ?? DEFAULT_STYLE.color;
+}
+
+export function getStatusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  return STATUS_MAP[status as LoteStatus]?.variant ?? DEFAULT_STYLE.variant;
+}
+
+export function getLoteStatusStyle(status: string) {
+  const color = getLoteColor(status);
+  return { color, weight: 2, fillColor: color, fillOpacity: 0.25 };
+}
+
+export function getLoteStyle(status: string, isHovered = false, isSelected = false) {
+  const baseColor = getLoteColor(status);
+  return {
+    color: isSelected ? '#1e40af' : baseColor,
+    weight: isSelected ? 3 : isHovered ? 2 : 1,
+    opacity: 1,
+    fillColor: baseColor,
+    fillOpacity: isHovered ? 0.7 : isSelected ? 0.8 : 0.5,
+    dashArray: status === 'reservado' ? '5, 5' : undefined,
+  };
+}

--- a/src/pages/admin/LotesVendas.tsx
+++ b/src/pages/admin/LotesVendas.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { supabase } from "@/lib/dataClient";
 import { LoteData, formatArea } from "@/lib/geojsonUtils";
+import { getStatusVariant, getLoteColor } from "@/lib/loteStyles";
 import { toast } from "sonner";
 import { Edit3, DollarSign, Users, TrendingUp } from "lucide-react";
 
@@ -197,14 +198,12 @@ export default function LotesVendas() {
   };
 
   const getStatusBadge = (status: string) => {
-    const config = {
-      'disponivel': { variant: 'secondary' as const, label: 'Disponível' },
-      'reservado': { variant: 'default' as const, label: 'Reservado' },
-      'vendido': { variant: 'destructive' as const, label: 'Vendido' }
+    const labelMap: Record<string, string> = {
+      disponivel: 'Disponível',
+      reservado: 'Reservado',
+      vendido: 'Vendido'
     };
-    
-    const { variant, label } = config[status as keyof typeof config] || config.disponivel;
-    return <Badge variant={variant}>{label}</Badge>;
+    return <Badge variant={getStatusVariant(status)}>{labelMap[status] || labelMap.disponivel}</Badge>;
   };
 
   return (
@@ -265,34 +264,34 @@ export default function LotesVendas() {
               <Card>
                 <CardContent className="p-4">
                   <div className="flex items-center space-x-2">
-                    <div className="w-3 h-3 bg-gray-400 rounded-full" />
+                    <div className="w-3 h-3 rounded-full" style={{ backgroundColor: getLoteColor('disponivel') }} />
                     <div>
                       <p className="text-xs text-muted-foreground">Disponível</p>
-                      <p className="text-xl font-bold text-gray-600">{stats.disponivel}</p>
+                      <p className="text-xl font-bold" style={{ color: getLoteColor('disponivel') }}>{stats.disponivel}</p>
                     </div>
                   </div>
                 </CardContent>
               </Card>
-              
+
               <Card>
                 <CardContent className="p-4">
                   <div className="flex items-center space-x-2">
-                    <div className="w-3 h-3 bg-yellow-400 rounded-full" />
+                    <div className="w-3 h-3 rounded-full" style={{ backgroundColor: getLoteColor('reservado') }} />
                     <div>
                       <p className="text-xs text-muted-foreground">Reservado</p>
-                      <p className="text-xl font-bold text-yellow-600">{stats.reservado}</p>
+                      <p className="text-xl font-bold" style={{ color: getLoteColor('reservado') }}>{stats.reservado}</p>
                     </div>
                   </div>
                 </CardContent>
               </Card>
-              
+
               <Card>
                 <CardContent className="p-4">
                   <div className="flex items-center space-x-2">
-                    <div className="w-3 h-3 bg-red-400 rounded-full" />
+                    <div className="w-3 h-3 rounded-full" style={{ backgroundColor: getLoteColor('vendido') }} />
                     <div>
                       <p className="text-xs text-muted-foreground">Vendido</p>
-                      <p className="text-xl font-bold text-red-600">{stats.vendido}</p>
+                      <p className="text-xl font-bold" style={{ color: getLoteColor('vendido') }}>{stats.vendido}</p>
                     </div>
                   </div>
                 </CardContent>

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,13 +1,10 @@
 import { FeatureCollection, Geometry } from "geojson";
+import { getLoteStatusStyle } from "@/lib/loteStyles";
 
 export type ValidGeoJSON = FeatureCollection<Geometry, any>;
 
 export function guessStatusStyle(status?: string) {
-  const s = (status || "").toString().toLowerCase();
-  if (s === "disponivel" || s === "disponível") return { color: "#00C26E", weight: 2, fillColor: "#00C26E", fillOpacity: 0.25 };
-  if (s === "reservado") return { color: "#E3B341", weight: 2, fillColor: "#E3B341", fillOpacity: 0.25 };
-  if (s === "vendido") return { color: "#F05252", weight: 2, fillColor: "#F05252", fillOpacity: 0.25 };
-  return { color: "#38BDF8", weight: 2, fillColor: "#38BDF8", fillOpacity: 0.2 };
+  return getLoteStatusStyle((status || "").toString().toLowerCase());
 }
 
 export function computeBBox(fc: ValidGeoJSON): [number, number, number, number] {


### PR DESCRIPTION
## Summary
- add `loteStyles` utility centralizing color, style and variant mapping for lot statuses
- refactor map and UI components to consume shared styles
- document status to color/variant mapping

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a266c197f0832a93c7e8cc1e168d0f