### PR TITLE
refactor: add shared types and typed Supabase queries

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,31 @@
+export interface Empreendimento {
+  id: string;
+  nome: string;
+  status?: string;
+  filial_id?: string | null;
+  total_lotes?: number;
+  bounds?: {
+    sw: { lat: number; lng: number } | [number, number];
+    ne: { lat: number; lng: number } | [number, number];
+  };
+  geojson_url?: string | null;
+  masterplan_url?: string | null;
+}
+
+export interface Lote {
+  id: string;
+  nome: string;
+  numero: number;
+  status: 'disponivel' | 'reservado' | 'vendido';
+  area_m2: number;
+  valor: number | null;
+  comprador_nome?: string | null;
+  comprador_email?: string | null;
+  observacoes?: string | null;
+}
+
+export interface AuthorizationProfile {
+  role: string;
+  panels: string[];
+  filial_id: string | null;
+}


### PR DESCRIPTION
## Summary
- define shared interfaces for Empreendimento, Lote, and AuthorizationProfile
- use typed Supabase generics in authorization and map pages
- remove `any` casts and align lote pricing field as `valor`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a266d9c18c832abd895a2ab0b5fdef