### PR TITLE
test: add geojson utility tests

### DIFF
--- a/src/lib/__tests__/geojsonUtils.test.ts
+++ b/src/lib/__tests__/geojsonUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { calculatePolygonArea, calculatePolygonCenter, processGeoJSON } from '../geojsonUtils';
+import { mockFeatureCollection } from '../../utils/geo';
+
+describe('geojsonUtils', () => {
+  const fc = mockFeatureCollection();
+  const polygon = fc.features[0].geometry.coordinates;
+
+  it('calculatePolygonArea returns 0 for provided polygon', () => {
+    const area = calculatePolygonArea(polygon as any);
+    expect(area).toBe(0);
+  });
+
+  it('calculatePolygonCenter computes centroid', () => {
+    const center = calculatePolygonCenter(polygon as any);
+    expect(center.lat).toBeCloseTo(-23.5476, 4);
+    expect(center.lng).toBeCloseTo(-46.6376, 4);
+  });
+
+  it('processGeoJSON processes valid data', () => {
+    const result = processGeoJSON(JSON.stringify(fc));
+    expect(result.totalLotes).toBe(2);
+    expect(result.lotes[0]).toMatchObject({
+      nome: 'Lote 1',
+      numero: 1,
+      properties: fc.features[0].properties,
+      status: 'disponivel'
+    });
+    expect(result.lotes[0].area_m2).toBe(calculatePolygonArea(polygon as any));
+    expect(result.lotes[0].coordenadas).toEqual(calculatePolygonCenter(polygon as any));
+    expect(result.bounds).toEqual({
+      sw: { lat: -23.5485, lng: -46.639 },
+      ne: { lat: -23.547, lng: -46.637 }
+    });
+  });
+
+  it('processGeoJSON throws on invalid JSON', () => {
+    expect(() => processGeoJSON('invalid')).toThrow('Arquivo GeoJSON inválido');
+  });
+
+  it('processGeoJSON throws on invalid geometry', () => {
+    const invalid = JSON.stringify({
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: [0, 0] } }
+      ]
+    });
+    expect(() => processGeoJSON(invalid)).toThrow('Arquivo GeoJSON inválido');
+  });
+});

--- a/src/utils/__tests__/geo.test.ts
+++ b/src/utils/__tests__/geo.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { parseAndValidateGeoJSON, guessStatusStyle, mockFeatureCollection } from '../geo';
+
+describe('geo utils', () => {
+  it('parseAndValidateGeoJSON parses valid feature collection', async () => {
+    const fc = mockFeatureCollection();
+    const { fc: parsed, featuresCount, bbox } = await parseAndValidateGeoJSON(JSON.stringify(fc));
+    expect(featuresCount).toBe(fc.features.length);
+    expect(parsed).toEqual(fc);
+    expect(bbox).toEqual([-46.639, -23.5485, -46.637, -23.547]);
+  });
+
+  it('parseAndValidateGeoJSON throws on invalid JSON', async () => {
+    await expect(parseAndValidateGeoJSON('invalid')).rejects.toThrow('JSON inválido');
+  });
+
+  it('parseAndValidateGeoJSON throws on invalid geometry', async () => {
+    const invalid = JSON.stringify({
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }
+      ]
+    });
+    await expect(parseAndValidateGeoJSON(invalid)).rejects.toThrow('Somente Polygon ou MultiPolygon são aceitos');
+  });
+
+  it('guessStatusStyle returns style for each status', () => {
+    expect(guessStatusStyle('disponivel')).toMatchObject({ color: '#00C26E' });
+    expect(guessStatusStyle('reservado')).toMatchObject({ color: '#E3B341' });
+    expect(guessStatusStyle('vendido')).toMatchObject({ color: '#F05252' });
+    expect(guessStatusStyle('outro')).toMatchObject({ color: '#38BDF8' });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for calculatePolygonArea, calculatePolygonCenter and processGeoJSON
- cover parseAndValidateGeoJSON and guessStatusStyle with success and error cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a266fb1f44832a83a0944d30e4f7ec