### PR TITLE
Validar envs do Supabase e fallback em testes

### DIFF
--- a/src/lib/dataClient.ts
+++ b/src/lib/dataClient.ts
@@ -3,15 +3,38 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    '❌ Supabase não configurado: defina VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY no arquivo .env.local'
-  )
+const isDev = import.meta.env.DEV
+const isTest = import.meta.env.MODE === 'test'
+
+function assertEnv(value: string | undefined, name: string) {
+  if (!value) {
+    const msg = `❌ ${name} não definida: adicione-a ao arquivo .env.local na raiz do projeto ou configure a variável de ambiente em produção.`
+    if (isDev && !isTest) {
+      throw new Error(msg)
+    } else {
+      console.warn(msg)
+    }
+  }
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-  },
-})
+assertEnv(supabaseUrl, 'VITE_SUPABASE_URL')
+assertEnv(supabaseAnonKey, 'VITE_SUPABASE_ANON_KEY')
+
+export const supabase =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+          persistSession: true,
+          autoRefreshToken: true,
+        },
+      })
+    : (new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(
+              'Supabase não configurado: defina VITE_SUPABASE_URL e VITE_SUPABASE_ANON_KEY no arquivo .env.local ou como variáveis de produção.'
+            )
+          },
+        }
+      ) as ReturnType<typeof createClient>)


### PR DESCRIPTION
## Summary
- valida cada variável de ambiente do Supabase com mensagens claras
- orienta configuração via `.env.local` ou variáveis de produção
- adiciona fallback que evita exceções em modo de testes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2672bd370832aad9ccde2c28b77a2