### PR TITLE
Add diagnostic RFC and index entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,7 @@ VITE_ADMIN_PASSWORD=strong-password
 Only roles with both variables defined will appear in the widget.
 
 This quick login widget is available only during development and returns nothing in production builds.
+
+## RFCs
+
+- [RFC-000: Diagnóstico](docs/RFC-000-diagnostico.md)

--- a/docs/RFC-000-diagnostico.md
+++ b/docs/RFC-000-diagnostico.md
@@ -1,0 +1,20 @@
+# RFC-000: Diagnóstico
+
+Este documento apresenta um diagnóstico inicial do projeto. O objetivo é registrar o estado atual da aplicação e indicar pontos de atenção para evolução futura.
+
+## Contexto
+
+A aplicação é um frontend construído com [Vite](https://vitejs.dev/), [React](https://react.dev/) e [TypeScript](https://www.typescriptlang.org/). Ela utiliza [Supabase](https://supabase.com/) como backend e segue a abordagem de UI do [shadcn/ui](https://ui.shadcn.com/).
+
+## Principais achados
+
+- A base de código encontra-se organizada e utiliza padrões modernos de desenvolvimento.
+- A documentação ainda é limitada e não há um índice de RFCs para centralizar discussões de arquitetura.
+- A cobertura de testes automatizados é mínima, o que dificulta evoluções seguras.
+
+## Recomendações
+
+- Consolidar RFCs para discutir decisões de arquitetura e registrar mudanças relevantes.
+- Expandir a documentação para facilitar a entrada de novos colaboradores.
+- Investir em testes automatizados e integração contínua para evitar regressões.
+


### PR DESCRIPTION
## Summary
- document project state and recommendations in RFC-000
- add RFC index in README referencing diagnostic document

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d90cf310832a867f7d874e5fd901