### PR TITLE
feat: add widget telemetry logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import ReportsDashboard from "./pages/admin/ReportsDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
+import WidgetTelemetryPage from "./pages/admin/WidgetTelemetry";
 
 const queryClient = new QueryClient();
 
@@ -79,6 +80,7 @@ const App = () => (
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
+            <Route path="/super-admin/widget-telemetry" element={<Protected allowedRoles={['superadmin']}><WidgetTelemetryPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />
             <Route path="/super-admin/tokenizacao" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Tokenização" /></Protected>} />

--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -18,6 +18,7 @@ export function QuickLoginWidget({ compact = false, className = "", allowedPanel
   const [loading, setLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [widgetId] = useState(() => crypto.randomUUID());
   const navigate = useNavigate();
 
     if (!import.meta.env.DEV) {
@@ -35,14 +36,20 @@ export function QuickLoginWidget({ compact = false, className = "", allowedPanel
     setLoading(cred.email);
     
     try {
-      const { data: res, error } = await supabase.auth.signInWithPassword({ 
-        email: cred.email, 
-        password: cred.password 
+      const { data: res, error } = await supabase.auth.signInWithPassword({
+        email: cred.email,
+        password: cred.password
       });
-      
-      if (error) { 
-        setError(error.message || "Falha ao entrar"); 
-        return; 
+
+      await supabase.rpc('log_widget_event', {
+        widget_id: widgetId,
+        evento: 'quick_login_attempt',
+        meta: { email: cred.email }
+      });
+
+      if (error) {
+        setError(error.message || "Falha ao entrar");
+        return;
       }
       
       if (res?.session) {

--- a/src/pages/admin/WidgetTelemetry.tsx
+++ b/src/pages/admin/WidgetTelemetry.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+
+interface StatRow {
+  evento: string;
+  total: number;
+}
+
+export default function WidgetTelemetryPage() {
+  const [rows, setRows] = useState<StatRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase
+      .rpc("widget_telemetry_stats")
+      .then(({ data, error }) => {
+        if (error) {
+          setError(error.message);
+        } else {
+          setRows((data as StatRow[]) || []);
+        }
+      });
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Widget Telemetry</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <ul className="space-y-2">
+        {rows.map((row) => (
+          <li key={row.evento} className="flex justify-between">
+            <span>{row.evento}</span>
+            <span>{row.total}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/supabase/migrations/20250220000000_widget_telemetry.sql
+++ b/supabase/migrations/20250220000000_widget_telemetry.sql
@@ -1,0 +1,30 @@
+create table if not exists public.widget_telemetry (
+    id uuid primary key default gen_random_uuid(),
+    widget_id uuid not null,
+    evento text not null,
+    meta jsonb,
+    created_at timestamptz default now()
+);
+
+create or replace function public.log_widget_event(widget_id uuid, evento text, meta jsonb)
+returns void
+language sql
+security definer
+as $$
+  insert into public.widget_telemetry(widget_id, evento, meta)
+  values (log_widget_event.widget_id, log_widget_event.evento, log_widget_event.meta);
+$$;
+
+grant execute on function public.log_widget_event(uuid, text, jsonb) to anon;
+
+create or replace function public.widget_telemetry_stats()
+returns table(evento text, total bigint)
+language sql
+security definer
+as $$
+  select evento, count(*) as total
+  from public.widget_telemetry
+  group by evento;
+$$;
+
+grant execute on function public.widget_telemetry_stats() to authenticated;


### PR DESCRIPTION
## Summary
- add widget_telemetry table and log_widget_event function
- track quick login usage via log_widget_event RPC
- add optional admin page to view aggregated widget telemetry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d963d9ac832aab458723caa41fd8