### PR TITLE
feat: add reservas cleanup

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,5 @@
+[functions.cleanup-reservations]
+verify_jwt = false
+
+[functions.cleanup-reservations.cron]
+schedule = "*/5 * * * *"

--- a/supabase/functions/cleanup-reservations/index.ts
+++ b/supabase/functions/cleanup-reservations/index.ts
@@ -1,0 +1,26 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+serve(async () => {
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { error, count } = await admin
+    .from("reservas")
+    .delete()
+    .lt("expires_at", new Date().toISOString())
+    .select("*", { count: "exact", head: true });
+
+  if (error) {
+    console.error("cleanup-reservations error", error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ deleted: count || 0 }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/migrations/20250209000000_create_reservas.sql
+++ b/supabase/migrations/20250209000000_create_reservas.sql
@@ -1,0 +1,33 @@
+create table if not exists public.reservas (
+    id uuid primary key default gen_random_uuid(),
+    lote_id uuid not null references public.lotes(id) on delete cascade,
+    filial_id uuid not null references public.filiais(id) on delete cascade,
+    nome text,
+    email text,
+    telefone text,
+    expires_at timestamptz not null,
+    created_at timestamptz default now(),
+    updated_at timestamptz default now()
+);
+
+create index if not exists idx_reservas_lote on public.reservas(lote_id);
+create index if not exists idx_reservas_filial on public.reservas(filial_id);
+
+create or replace function public.reservas_set_filial()
+returns trigger language plpgsql as $$
+begin
+  select filial_id into new.filial_id from public.lotes where id = new.lote_id;
+  return new;
+end $$;
+
+create trigger tg_reservas_set_filial before insert on public.reservas
+    for each row execute function public.reservas_set_filial();
+
+create trigger tg_reservas_updated_at before update on public.reservas
+    for each row execute function public.set_updated_at();
+
+alter table public.reservas enable row level security;
+
+create policy reservas_rls on public.reservas for all
+  using (filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid)
+  with check (filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid);


### PR DESCRIPTION
## Summary
- add reservas table with filial inheritance and RLS
- schedule cleanup cron and function for expired reservations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d96d6d4c832a9992c2c52bb1d677