### PR TITLE
Add audit logging for reservas and capture client info

### DIFF
--- a/src/pages/admin/AuditLogsFilial.tsx
+++ b/src/pages/admin/AuditLogsFilial.tsx
@@ -27,6 +27,8 @@ interface AuditLog {
   action: string;
   target: string | null;
   metadata: any;
+  ip_address: string | null;
+  user_agent: string | null;
   created_at: string;
 }
 
@@ -54,7 +56,7 @@ export default function AuditLogsFilialPage() {
     setLoading(true);
     let query = supabase
       .from("audit_logs")
-      .select("id, actor, action, target, metadata, created_at")
+      .select("id, actor, action, target, metadata, ip_address, user_agent, created_at")
       .order("created_at", { ascending: false });
 
     query = query.contains("metadata", { filial_id: filialId });
@@ -140,6 +142,8 @@ export default function AuditLogsFilialPage() {
                       <TableHead>Usuário</TableHead>
                       <TableHead>Ação</TableHead>
                       <TableHead>Alvo</TableHead>
+                      <TableHead>IP</TableHead>
+                      <TableHead>User Agent</TableHead>
                       <TableHead>Detalhes</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -150,6 +154,8 @@ export default function AuditLogsFilialPage() {
                         <TableCell className="font-mono">{log.actor}</TableCell>
                         <TableCell>{log.action}</TableCell>
                         <TableCell className="font-mono">{log.target ?? "—"}</TableCell>
+                        <TableCell className="font-mono">{log.ip_address ?? "—"}</TableCell>
+                        <TableCell className="max-w-xs truncate">{log.user_agent ?? "—"}</TableCell>
                         <TableCell className="max-w-xs truncate">{JSON.stringify(log.metadata ?? {})}</TableCell>
                       </TableRow>
                     ))}

--- a/supabase/functions/admin-update-filial-billing/index.ts
+++ b/supabase/functions/admin-update-filial-billing/index.ts
@@ -82,11 +82,16 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: error.message }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
+    const ipAddress = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      req.headers.get("x-real-ip") || "";
+    const userAgent = req.headers.get("user-agent") || "";
     await adminClient.from('audit_logs').insert({
       actor: user.id,
       action: 'admin-update-filial-billing',
       target: filial_id,
-      metadata: { action, plan }
+      metadata: { action, plan },
+      ip_address: ipAddress,
+      user_agent: userAgent,
     }).catch(() => {});
 
     return new Response(JSON.stringify({ success: true }), { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } });

--- a/supabase/migrations/20250209000000_audit_reservas.sql
+++ b/supabase/migrations/20250209000000_audit_reservas.sql
@@ -1,0 +1,47 @@
+create table if not exists public.audit_reservas (
+    id uuid primary key default gen_random_uuid(),
+    reserva_id uuid not null,
+    action text not null,
+    actor uuid,
+    old_row jsonb,
+    new_row jsonb,
+    ip_address text,
+    user_agent text,
+    created_at timestamptz not null default now()
+);
+
+create or replace function public.log_reserva_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_headers json;
+  v_ip text;
+  v_ua text;
+begin
+  v_headers := current_setting('request.headers', true)::json;
+  v_ip := coalesce(v_headers->>'x-forwarded-for', v_headers->>'x-real-ip');
+  v_ua := v_headers->>'user-agent';
+
+  if TG_OP = 'INSERT' then
+    insert into public.audit_reservas(reserva_id, action, actor, new_row, ip_address, user_agent)
+    values (new.id, TG_OP, auth.uid(), to_jsonb(new), v_ip, v_ua);
+    return new;
+  elsif TG_OP = 'UPDATE' then
+    insert into public.audit_reservas(reserva_id, action, actor, old_row, new_row, ip_address, user_agent)
+    values (new.id, TG_OP, auth.uid(), to_jsonb(old), to_jsonb(new), v_ip, v_ua);
+    return new;
+  elsif TG_OP = 'DELETE' then
+    insert into public.audit_reservas(reserva_id, action, actor, old_row, ip_address, user_agent)
+    values (old.id, TG_OP, auth.uid(), to_jsonb(old), v_ip, v_ua);
+    return old;
+  end if;
+end;
+$$;
+
+drop trigger if exists log_reserva_change on public.reservas;
+create trigger log_reserva_change
+after insert or update or delete on public.reservas
+for each row execute function public.log_reserva_change();


### PR DESCRIPTION
## Summary
- create `audit_reservas` table and trigger `log_reserva_change`
- log `ip_address` and `user_agent` in admin billing edge function
- show client info in filial audit log page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9859000832ab0a02bd1c6893562