### PR TITLE
Add DOCX rendering edge function and template management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import ReportsDashboard from "./pages/admin/ReportsDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
+import ContratosPage from "./pages/admin/Contratos";
 
 const queryClient = new QueryClient();
 
@@ -77,6 +78,7 @@ const App = () => (
             <Route path="/super-admin/filiais-acessos" element={<Protected allowedRoles={['superadmin']}><FiliaisAccessPage /></Protected>} />
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
+            <Route path="/super-admin/contratos" element={<Protected allowedRoles={['superadmin']}><ContratosPage /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -22,6 +22,7 @@ export const NAV: Record<string, NavItem[]> = {
     { label: "Usuários", href: "/super-admin/usuarios", icon: "user" },
     { label: "Aprovação", href: "/super-admin/aprovacao", icon: "check-circle" },
     { label: "Tokenização", href: "/super-admin/tokenizacao", icon: "key" },
+    { label: "Contratos", href: "/super-admin/contratos", icon: "file-text" },
     { label: "Auditoria", href: "/super-admin/auditoria", icon: "file-text" },
 
     { label: "Relatórios", href: "/super-admin/relatorios", icon: "bar-chart-2" },

--- a/src/pages/admin/Contratos.tsx
+++ b/src/pages/admin/Contratos.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { AppShell } from "@/components/shell/AppShell";
+import { Protected } from "@/components/Protected";
+import { supabase } from "@/lib/dataClient";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { DataTable, Column } from "@/components/app/DataTable";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+
+interface Filial { id: string; nome: string; }
+interface TemplateRow { id: string; name: string; filial: string; storage_path: string; }
+
+export default function ContratosPage() {
+  const [filiais, setFiliais] = useState<Filial[]>([]);
+  const [templates, setTemplates] = useState<TemplateRow[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const [filialId, setFilialId] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadFiliais();
+    loadTemplates();
+  }, []);
+
+  async function loadFiliais() {
+    const { data } = await supabase.from("filiais").select("id, nome").order("nome");
+    setFiliais(data || []);
+  }
+
+  async function loadTemplates() {
+    const { data, error } = await supabase
+      .from("doc_templates")
+      .select("id, name, storage_path, filiais(nome)")
+      .order("created_at", { ascending: false });
+    if (error) toast.error("Erro ao carregar templates: " + error.message);
+    const rows = (data || []).map((t: any) => ({
+      id: t.id,
+      name: t.name,
+      filial: t.filiais?.nome || "",
+      storage_path: t.storage_path,
+    }));
+    setTemplates(rows);
+  }
+
+  async function handleUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file || !name.trim() || !filialId) {
+      toast.error("Informe nome, arquivo e filial");
+      return;
+    }
+    setLoading(true);
+    try {
+      const fileName = `${Date.now()}-${file.name.replace(/\s/g, "_")}`;
+      const { error: uploadError } = await supabase.storage.from("doc-templates").upload(fileName, file);
+      if (uploadError) throw uploadError;
+      const { error: insertError } = await supabase.from("doc_templates").insert({
+        name: name.trim(),
+        filial_id: filialId,
+        storage_path: fileName,
+      });
+      if (insertError) throw insertError;
+      toast.success("Template enviado");
+      setFile(null);
+      setName("");
+      setFilialId("");
+      await loadTemplates();
+    } catch (err: any) {
+      toast.error("Falha no upload: " + err.message);
+    }
+    setLoading(false);
+  }
+
+  const columns: Column[] = [
+    { key: "name", header: "Nome" },
+    { key: "filial", header: "Filial" },
+    { key: "storage_path", header: "Arquivo" },
+  ];
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: "Super Admin", href: "/super-admin" }, { label: "Contratos" }]}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Novo Template</CardTitle>
+          <CardDescription>Envie um modelo de contrato</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleUpload} className="flex flex-col gap-2">
+            <Input type="text" placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
+            <Select value={filialId} onValueChange={setFilialId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Filial" />
+              </SelectTrigger>
+              <SelectContent>
+                {filiais.map((f) => (
+                  <SelectItem key={f.id} value={f.id}>{f.nome}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input type="file" accept=".docx" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+            <Button type="submit" disabled={loading}>Enviar</Button>
+          </form>
+        </CardContent>
+      </Card>
+      <Card className="mt-4">
+        <CardHeader>
+          <CardTitle>Templates</CardTitle>
+          <CardDescription>Modelos cadastrados</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <DataTable columns={columns} rows={templates} />
+        </CardContent>
+      </Card>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/functions/render-docx/index.ts
+++ b/supabase/functions/render-docx/index.ts
@@ -1,0 +1,46 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+let cachedRender: ((text: string) => Promise<Uint8Array>) | null = null;
+
+async function getRenderer() {
+  if (cachedRender) return cachedRender;
+  const code = `import { Document, Packer, Paragraph } from "npm:docx";
+export async function render(text) {
+  const doc = new Document({ sections: [{ children: [new Paragraph(text)] }] });
+  return Packer.toBuffer(doc);
+}`;
+  const { files } = await Deno.emit("/mod.ts", { sources: { "/mod.ts": code }, bundle: "module" });
+  const dataUrl = "data:application/javascript," + encodeURIComponent(files["deno:///bundle.js"]);
+  const mod = await import(dataUrl);
+  cachedRender = mod.render;
+  return cachedRender;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), { status: 405, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  }
+  try {
+    const { text } = await req.json();
+    const render = await getRenderer();
+    const bytes = await render(text || "");
+    return new Response(bytes, {
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+    });
+  } catch (e) {
+    console.error("render-docx error", e);
+    return new Response(JSON.stringify({ error: String(e?.message || e) }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  }
+});

--- a/supabase/migrations/20250209000000_create_doc_templates.sql
+++ b/supabase/migrations/20250209000000_create_doc_templates.sql
@@ -1,0 +1,7 @@
+create table if not exists public.doc_templates (
+    id uuid primary key default gen_random_uuid(),
+    filial_id uuid references filiais(id),
+    name text not null,
+    storage_path text not null,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- add `render-docx` edge function bundling npm docx via Deno.emit
- create `doc_templates` table migration
- build super-admin contracts page with upload and list interface

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d9936cdc832a8d0375014450eedb