### PR TITLE
feat: payment reconciliation and delinquency dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import MapaSuperAdmin from "./pages/admin/MapaSuperAdmin";
 import AuditLogsPage from "./pages/admin/AuditLogs";
 import AuditLogsFilialPage from "./pages/admin/AuditLogsFilial";
 import ReportsDashboard from "./pages/admin/ReportsDashboard";
+import InadimplenciaDashboard from "./pages/admin/InadimplenciaDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
@@ -84,6 +85,7 @@ const App = () => (
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
+            <Route path="/super-admin/inadimplencia" element={<Protected allowedRoles={['superadmin']}><InadimplenciaDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />

--- a/src/pages/admin/InadimplenciaDashboard.tsx
+++ b/src/pages/admin/InadimplenciaDashboard.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { KPIStat } from "@/components/app/KPIStat";
+import { DataTable } from "@/components/app/DataTable";
+
+export default function InadimplenciaDashboard() {
+  const [rows, setRows] = useState<any[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("conciliacoes")
+      .select("referencia, valor, status")
+      .eq("status", "pendente")
+      .then(({ data }) => setRows(data ?? []));
+  }, []);
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell
+        menuKey="superadmin"
+        breadcrumbs={[{ label: "Super Admin" }, { label: "Inadimplência" }]}
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          <KPIStat label="Pendentes" value={rows.length} />
+        </div>
+        <DataTable
+          columns={[
+            { key: "referencia", header: "Referência" },
+            { key: "valor", header: "Valor" },
+            { key: "status", header: "Status" },
+          ]}
+          rows={rows}
+          pageSize={10}
+        />
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/functions/reconcile-payments/index.ts
+++ b/supabase/functions/reconcile-payments/index.ts
@@ -1,0 +1,89 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import * as Sentry from "https://esm.sh/@sentry/deno@7";
+
+Sentry.init({ dsn: Deno.env.get("SENTRY_DSN") || "" });
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { type, data } = await req.json();
+    if (!type || !data) {
+      return new Response(JSON.stringify({ error: "type e data são obrigatórios" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+
+    let records: Array<Record<string, unknown>> = [];
+    if (type === "pix" && Array.isArray(data)) {
+      records = data.map((p: any) => ({
+        tipo: "pix",
+        referencia: p.txid || p.e2eId || null,
+        valor: p.valor || p.amount || null,
+        status: p.status || "pendente",
+        dados: p,
+      }));
+    } else if (type === "cnab" && typeof data === "string") {
+      const lines = data.split(/\r?\n/).filter(Boolean);
+      records = lines.map((line) => ({
+        tipo: "cnab",
+        referencia: line.slice(0, 20).trim(),
+        valor: Number(line.slice(20, 32)) || null,
+        status: "pendente",
+        dados: { raw: line },
+      }));
+    } else {
+      return new Response(JSON.stringify({ error: "formato de data inválido" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!records.length) {
+      return new Response(JSON.stringify({ error: "sem registros" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { error } = await admin.from("conciliacoes").insert(records);
+    if (error) {
+      throw error;
+    }
+
+    return new Response(JSON.stringify({ inserted: records.length }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    Sentry.captureException(e);
+    console.error("reconcile-payments error", e);
+    return new Response(
+      JSON.stringify({ error: String((e as any)?.message || e) }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+});
+

--- a/supabase/migrations/20250326000000_create_conciliacoes.sql
+++ b/supabase/migrations/20250326000000_create_conciliacoes.sql
@@ -1,0 +1,10 @@
+create table if not exists public.conciliacoes (
+    id uuid primary key default gen_random_uuid(),
+    tipo text not null,
+    referencia text,
+    valor numeric,
+    status text not null default 'pendente',
+    dados jsonb,
+    conciliado_em timestamp with time zone,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- add `reconcile-payments` edge function with PIX/CNAB parsing
- create `conciliacoes` table migration
- expose pending reconciliations in new admin dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4db1f7618832a8da833e1d92cb700