### PR TITLE
feat: add cliente role and extrato page

### DIFF
--- a/NovoSetup/scripts/direct-database-fixes.js
+++ b/NovoSetup/scripts/direct-database-fixes.js
@@ -107,7 +107,7 @@ async function directFixes() {
                   email: user.email,
                   full_name: user.full_name,
                   role: user.role,
-                  panels: user.role === 'superadmin' ? ['superadmin', 'adminfilial'] : ['adminfilial'],
+                  panels: user.role === 'superadmin' ? ['superadmin', 'adminfilial', 'cliente'] : ['adminfilial'],
                   is_active: true
                 });
                 

--- a/NovoSetup/scripts/supabase-complete-setup.js
+++ b/NovoSetup/scripts/supabase-complete-setup.js
@@ -64,7 +64,7 @@ async function completeSupabaseSetup() {
         password: 'BlockUrb2024!',
         full_name: 'Super Administrador',
         role: 'superadmin',
-        panels: ['superadmin', 'adminfilial', 'urbanista', 'juridico', 'contabilidade', 'marketing', 'comercial', 'imobiliaria', 'corretor', 'obras', 'investidor', 'terrenista']
+        panels: ['superadmin', 'adminfilial', 'urbanista', 'juridico', 'contabilidade', 'marketing', 'comercial', 'imobiliaria', 'corretor', 'obras', 'investidor', 'terrenista', 'cliente']
       },
       {
         email: 'admin@blockurb.com',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,7 +176,11 @@ const App = () => (
             <Route path="/terrenista/config" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Configurações" /></Protected>} />
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
-            
+
+            {/* Cliente */}
+            <Route path="/cliente" element={<Protected allowedRoles={['cliente']}><PanelHomePage menuKey="cliente" title="Cliente" /></Protected>} />
+            <Route path="/cliente/extrato" element={<Protected allowedRoles={['cliente']}><PanelSectionPage menuKey="cliente" title="Cliente" section="Extrato" /></Protected>} />
+
             {/* Debug route */}
               <Route
                 path="/debug/connection"

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -11,6 +11,7 @@ export const scopeRoutes = {
   obras: "/obras",
   investidor: "/investidor",
   terrenista: "/terrenista",
+  cliente: "/cliente",
 } as const;
 
 export type AuthScope = keyof typeof scopeRoutes;
@@ -30,6 +31,7 @@ const scopeLabels: Record<AuthScope, string> = {
   obras: "Obras",
   investidor: "Investidor",
   terrenista: "Terrenista",
+  cliente: "Cliente",
 };
 
 export function labelFromScope(scope?: string | null): string | undefined {

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -79,6 +79,10 @@ export const NAV: Record<string, NavItem[]> = {
     { title: "Terrenista", href: "/terrenista", icon: "landmark" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
+  cliente: [
+    { title: "Extrato", href: "/cliente/extrato", icon: "file-text" },
+    { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
+  ],
 };
 
 export function inferMenuKey(pathname: string) {

--- a/src/pages/cliente/Extrato.tsx
+++ b/src/pages/cliente/Extrato.tsx
@@ -1,0 +1,5 @@
+import { PanelSectionPage } from "@/components/panels/PanelPages";
+
+export default function ClienteExtratoPage() {
+  return <PanelSectionPage menuKey="cliente" title="Cliente" section="Extrato" />;
+}


### PR DESCRIPTION
## Summary
- add cliente role to auth config and navigation
- create protected extrato page for cliente
- update provisioning scripts to include cliente panel

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4db2191e4832a82532e56a96367ea