### PR TITLE
feat: add renegociacoes panel and email confirmations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
 import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
+import RenegociacoesPage from "./pages/juridico/Renegociacoes";
 
 const queryClient = new QueryClient();
 
@@ -120,6 +121,7 @@ const App = () => (
             <Route path="/juridico/config" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Configurações" /></Protected>} />
             <Route path="/juridico/contratos" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Contratos" /></Protected>} />
             <Route path="/juridico/processos" element={<Protected allowedRoles={['juridico']}><PanelSectionPage menuKey="juridico" title="Jurídico" section="Processos" /></Protected>} />
+            <Route path="/juridico/renegociacoes" element={<Protected allowedRoles={['juridico']}><RenegociacoesPage /></Protected>} />
 
             {/* Contabilidade */}
             <Route path="/contabilidade" element={<Protected allowedRoles={['contabilidade']}><PanelHomePage menuKey="contabilidade" title="Contabilidade" /></Protected>} />

--- a/src/pages/juridico/Renegociacoes.tsx
+++ b/src/pages/juridico/Renegociacoes.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Button } from "@/components/ui/button";
+import { DataTable, Column } from "@/components/app/DataTable";
+import { supabase } from "@/lib/dataClient";
+
+interface Renegociacao {
+  id: string;
+  reserva_id: string;
+  email: string;
+  status: string;
+  created_at: string;
+}
+
+const columns: Column[] = [
+  { key: "reserva_id", header: "Reserva" },
+  { key: "email", header: "E-mail" },
+  { key: "status", header: "Status" },
+  { key: "actions", header: "Ações", render: (row) => row.actions },
+];
+
+export default function RenegociacoesPage() {
+  const [items, setItems] = useState<Renegociacao[]>([]);
+
+  async function load() {
+    const { data } = await supabase
+      .from("renegociacoes")
+      .select("id, reserva_id, email, status, created_at")
+      .order("created_at", { ascending: false });
+    setItems((data as Renegociacao[]) || []);
+  }
+
+  useEffect(() => {
+    document.title = "Renegociações | BlockURB";
+    load();
+  }, []);
+
+  async function handleAction(id: string, email: string, status: string) {
+    await supabase.from("renegociacoes").update({ status }).eq("id", id);
+    if (status === "approved") {
+      await supabase.functions.invoke("renegociacao-confirm", {
+        body: { email, status },
+      });
+    }
+    await load();
+  }
+
+  const rows = items.map((item) => ({
+    ...item,
+    actions: (
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => handleAction(item.id, item.email, "approved")}>Aprovar</Button>
+        <Button size="sm" variant="destructive" onClick={() => handleAction(item.id, item.email, "rejected")}>Rejeitar</Button>
+      </div>
+    ),
+  }));
+
+  return (
+    <Protected allowedRoles={['juridico']}>
+      <AppShell
+        menuKey="juridico"
+        breadcrumbs={[
+          { label: "Home", href: "/" },
+          { label: "Jurídico" },
+          { label: "Renegociações" },
+        ]}
+      >
+        <div className="space-y-6">
+          <DataTable columns={columns} rows={rows} pageSize={10} />
+        </div>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/functions/renegociacao-confirm/index.ts
+++ b/supabase/functions/renegociacao-confirm/index.ts
@@ -1,0 +1,34 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import * as Sentry from "https://esm.sh/@sentry/deno@7";
+
+Sentry.init({ dsn: Deno.env.get("SENTRY_DSN") || "" });
+
+const NOTIFY_URL = Deno.env.get("NOTIFY_WEBHOOK_URL") || "";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { email, status } = await req.json();
+    if (NOTIFY_URL && email) {
+      await fetch(NOTIFY_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, status }),
+      }).catch(() => {});
+    }
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  } catch (e) {
+    Sentry.captureException(e);
+    console.error("renegociacao-confirm error", e);
+    return new Response(JSON.stringify({ error: String((e as any)?.message || e) }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+  }
+});

--- a/supabase/migrations/20250327000000_create_renegociacoes.sql
+++ b/supabase/migrations/20250327000000_create_renegociacoes.sql
@@ -1,0 +1,64 @@
+create table if not exists public.renegociacoes (
+    id uuid primary key default gen_random_uuid(),
+    reserva_id uuid not null references public.reservas(id) on delete cascade,
+    email text not null,
+    status text not null default 'pending',
+    created_at timestamptz default now(),
+    updated_at timestamptz default now()
+);
+
+create trigger tg_renegociacoes_updated_at before update on public.renegociacoes
+    for each row execute function public.set_updated_at();
+
+alter table public.renegociacoes enable row level security;
+
+create policy renegociacoes_rls on public.renegociacoes for all
+  using (true) with check (true);
+
+create table if not exists public.audit_renegociacoes (
+    id uuid primary key default gen_random_uuid(),
+    renegociacao_id uuid not null,
+    action text not null,
+    actor uuid,
+    old_row jsonb,
+    new_row jsonb,
+    ip_address text,
+    user_agent text,
+    created_at timestamptz not null default now()
+);
+
+create or replace function public.log_renegociacao_change()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_headers json;
+  v_ip text;
+  v_ua text;
+begin
+  v_headers := current_setting('request.headers', true)::json;
+  v_ip := coalesce(v_headers->>'x-forwarded-for', v_headers->>'x-real-ip');
+  v_ua := v_headers->>'user-agent';
+
+  if TG_OP = 'INSERT' then
+    insert into public.audit_renegociacoes(renegociacao_id, action, actor, new_row, ip_address, user_agent)
+    values (new.id, TG_OP, auth.uid(), to_jsonb(new), v_ip, v_ua);
+    return new;
+  elsif TG_OP = 'UPDATE' then
+    insert into public.audit_renegociacoes(renegociacao_id, action, actor, old_row, new_row, ip_address, user_agent)
+    values (new.id, TG_OP, auth.uid(), to_jsonb(old), to_jsonb(new), v_ip, v_ua);
+    return new;
+  elsif TG_OP = 'DELETE' then
+    insert into public.audit_renegociacoes(renegociacao_id, action, actor, old_row, ip_address, user_agent)
+    values (old.id, TG_OP, auth.uid(), to_jsonb(old), v_ip, v_ua);
+    return old;
+  end if;
+end;
+$$;
+
+drop trigger if exists log_renegociacao_change on public.renegociacoes;
+create trigger log_renegociacao_change
+after insert or update or delete on public.renegociacoes
+for each row execute function public.log_renegociacao_change();


### PR DESCRIPTION
## Summary
- add `renegociacoes` table with audit trigger
- create juridico approval panel and route
- send confirmation emails via edge function

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4db247dfc832a97bff3d82083c3c3