### PR TITLE
Add vendas table with RLS and basic sales UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import EmpreendimentosPage from "./pages/admin/Empreendimentos";
 import AdminMapa from "./pages/admin/Mapa";
 import MapaInterativo from "./pages/admin/MapaInterativo";
 import LotesVendas from "./pages/admin/LotesVendas";
+import VendaLancamento from "./pages/admin/VendaLancamento";
+import RelatorioComissoes from "./pages/admin/RelatorioComissoes";
 import AssinaturasPage from "./pages/admin/Assinaturas";
 import Aprovacao from "./pages/admin/Aprovacao";
 import Logout from "./pages/Logout";
@@ -101,6 +103,8 @@ const App = () => (
             <Route path="/admin-filial/mapa-interativo" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><MapaInterativo /></Protected>} />
             <Route path="/admin-filial/lotes" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><LotesPage /></Protected>} />
             <Route path="/admin-filial/lotes-vendas" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><LotesVendas /></Protected>} />
+            <Route path="/admin-filial/vendas/novo" element={<Protected allowedRoles={['adminfilial', 'comercial', 'superadmin']} panelKey="adminfilial"><VendaLancamento /></Protected>} />
+            <Route path="/admin-filial/comissoes" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><RelatorioComissoes /></Protected>} />
             <Route path="/admin-filial/assinaturas" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><AssinaturasPage /></Protected>} />
             <Route path="/admin-filial/auditoria" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><AuditLogsFilialPage /></Protected>} />
 
@@ -141,6 +145,8 @@ const App = () => (
             <Route path="/comercial/config" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Configurações" /></Protected>} />
             <Route path="/comercial/leads" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Leads" /></Protected>} />
             <Route path="/comercial/propostas" element={<Protected allowedRoles={['comercial']}><PanelSectionPage menuKey="comercial" title="Comercial" section="Propostas" /></Protected>} />
+            <Route path="/comercial/vendas/nova" element={<Protected allowedRoles={['comercial', 'adminfilial', 'superadmin']} panelKey="comercial"><VendaLancamento /></Protected>} />
+            <Route path="/comercial/comissoes" element={<Protected allowedRoles={['comercial', 'superadmin']} panelKey="comercial"><RelatorioComissoes /></Protected>} />
 
             {/* Imobiliária */}
             <Route path="/imobiliaria" element={<Protected allowedRoles={['imobiliaria']}><PanelHomePage menuKey="imobiliaria" title="Imobiliária" /></Protected>} />

--- a/src/pages/admin/RelatorioComissoes.tsx
+++ b/src/pages/admin/RelatorioComissoes.tsx
@@ -1,0 +1,60 @@
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ComissaoRow {
+  corretor_id: string;
+  total: number;
+}
+
+export default function RelatorioComissoes() {
+  const [rows, setRows] = useState<ComissaoRow[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase.from("vendas").select("corretor_id, comissao");
+      if (!error && data) {
+        const grouped: Record<string, number> = {};
+        data.forEach(v => {
+          grouped[v.corretor_id] = (grouped[v.corretor_id] || 0) + Number(v.comissao);
+        });
+        const list = Object.entries(grouped).map(([corretor_id, total]) => ({ corretor_id, total }));
+        setRows(list);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <Protected>
+      <AppShell>
+        <Card>
+          <CardHeader>
+            <CardTitle>Comissões por Corretor</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Corretor</TableHead>
+                  <TableHead>Total Comissão</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map(r => (
+                  <TableRow key={r.corretor_id}>
+                    <TableCell>{r.corretor_id}</TableCell>
+                    <TableCell>{r.total.toFixed(2)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/src/pages/admin/VendaLancamento.tsx
+++ b/src/pages/admin/VendaLancamento.tsx
@@ -1,0 +1,69 @@
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { toast } from "sonner";
+
+export default function VendaLancamento() {
+  const [form, setForm] = useState({
+    lote_id: "",
+    filial_id: "",
+    corretor_id: "",
+    valor: "",
+    comissao: ""
+  });
+
+  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm(prev => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleSubmit = async () => {
+    const { error } = await supabase.from("vendas").insert({
+      lote_id: form.lote_id,
+      filial_id: form.filial_id,
+      corretor_id: form.corretor_id,
+      valor: Number(form.valor),
+      comissao: Number(form.comissao)
+    });
+    if (error) {
+      console.error(error);
+      toast.error("Erro ao lançar venda");
+    } else {
+      toast.success("Venda lançada");
+      setForm({ lote_id: "", filial_id: "", corretor_id: "", valor: "", comissao: "" });
+    }
+  };
+
+  return (
+    <Protected>
+      <AppShell>
+        <div className="max-w-md space-y-4">
+          <div>
+            <Label htmlFor="lote">Lote ID</Label>
+            <Input id="lote" value={form.lote_id} onChange={handleChange("lote_id")} />
+          </div>
+          <div>
+            <Label htmlFor="filial">Filial ID</Label>
+            <Input id="filial" value={form.filial_id} onChange={handleChange("filial_id")} />
+          </div>
+          <div>
+            <Label htmlFor="corretor">Corretor ID</Label>
+            <Input id="corretor" value={form.corretor_id} onChange={handleChange("corretor_id")} />
+          </div>
+          <div>
+            <Label htmlFor="valor">Valor</Label>
+            <Input id="valor" type="number" value={form.valor} onChange={handleChange("valor")} />
+          </div>
+          <div>
+            <Label htmlFor="comissao">Comissão</Label>
+            <Input id="comissao" type="number" value={form.comissao} onChange={handleChange("comissao")} />
+          </div>
+          <Button onClick={handleSubmit}>Lançar venda</Button>
+        </div>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,3 +30,13 @@ export interface AuthorizationProfile {
   panels: string[];
   filial_id: string | null;
 }
+
+export interface Venda {
+  id: string;
+  lote_id: string;
+  filial_id: string;
+  corretor_id: string;
+  valor: number;
+  comissao: number;
+  created_at?: string;
+}

--- a/supabase/migrations/20250601000000_create_vendas.sql
+++ b/supabase/migrations/20250601000000_create_vendas.sql
@@ -1,0 +1,24 @@
+create table if not exists public.vendas (
+    id uuid primary key default gen_random_uuid(),
+    lote_id uuid not null references public.lotes(id) on delete cascade,
+    filial_id uuid not null references public.filiais(id) on delete cascade,
+    corretor_id uuid not null references auth.users(id) on delete cascade,
+    valor numeric not null,
+    comissao numeric not null,
+    created_at timestamptz default now()
+);
+
+create index if not exists idx_vendas_filial on public.vendas(filial_id);
+create index if not exists idx_vendas_corretor on public.vendas(corretor_id);
+
+alter table public.vendas enable row level security;
+
+create policy vendas_rls on public.vendas for all
+  using (
+    filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid and
+    corretor_id = current_setting('request.jwt.claims.corretor_id', true)::uuid
+  )
+  with check (
+    filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid and
+    corretor_id = current_setting('request.jwt.claims.corretor_id', true)::uuid
+  );


### PR DESCRIPTION
## Summary
- add vendas table migration with branch and broker row-level security
- introduce Venda type and sales entry form for admins and commercial team
- include commission report page grouped by broker

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4db2586c8832ab02fb32a3bd651b9