### PR TITLE
feat: add BI materialized views and refresh cron

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -3,3 +3,9 @@ verify_jwt = false
 
 [functions.cleanup-reservations.cron]
 schedule = "*/5 * * * *"
+
+[functions.refresh-bi]
+verify_jwt = false
+
+[functions.refresh-bi.cron]
+schedule = "0 * * * *"

--- a/supabase/functions/refresh-bi/index.ts
+++ b/supabase/functions/refresh-bi/index.ts
@@ -1,0 +1,20 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+serve(async () => {
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+  const { error } = await admin.rpc("refresh_bi");
+  if (error) {
+    console.error("refresh-bi error", error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return new Response(JSON.stringify({ success: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+});

--- a/supabase/migrations/20250701000000_create_mv_kpis_heatmap.sql
+++ b/supabase/migrations/20250701000000_create_mv_kpis_heatmap.sql
@@ -1,0 +1,49 @@
+-- Create materialized views for BI
+
+create materialized view if not exists public.mv_kpis_filial as
+  select
+    f.id as filial_id,
+    count(distinct e.id) as empreendimentos,
+    count(distinct u.user_id) filter (where u.role <> 'superadmin') as usuarios,
+    count(l.id) filter (where l.status = 'disponivel') as lotes_disponiveis,
+    count(l.id) filter (where l.status = 'reservado') as lotes_reservados,
+    count(l.id) filter (where l.status = 'vendido') as lotes_vendidos,
+    count(l.id) as total_lotes
+  from public.filiais f
+  left join public.empreendimentos e on e.filial_id = f.id
+  left join public.user_profiles u on u.filial_id = f.id
+  left join public.lotes l on l.filial_id = f.id
+  group by f.id;
+
+create unique index if not exists idx_mv_kpis_filial_filial on public.mv_kpis_filial(filial_id);
+
+create materialized view if not exists public.mv_heatmap_lotes as
+  select
+    filial_id,
+    st_x(geom) as longitude,
+    st_y(geom) as latitude,
+    status
+  from public.lotes
+  where geom is not null;
+
+create index if not exists idx_mv_heatmap_lotes_filial on public.mv_heatmap_lotes(filial_id);
+
+-- Restrict read permissions
+revoke all on public.mv_kpis_filial from public;
+revoke all on public.mv_heatmap_lotes from public;
+grant select on public.mv_kpis_filial to adminfilial, superadmin;
+grant select on public.mv_heatmap_lotes to adminfilial, superadmin;
+
+-- Function to refresh materialized views
+create or replace function public.refresh_bi()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  refresh materialized view public.mv_kpis_filial;
+  refresh materialized view public.mv_heatmap_lotes;
+end;
+$$;
+
+grant execute on function public.refresh_bi() to adminfilial, superadmin;

--- a/supabase/rpc/refresh_bi.sql
+++ b/supabase/rpc/refresh_bi.sql
@@ -1,0 +1,10 @@
+create or replace function public.refresh_bi()
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  refresh materialized view public.mv_kpis_filial;
+  refresh materialized view public.mv_heatmap_lotes;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add mv_kpis_filial and mv_heatmap_lotes materialized views with refresh function
- schedule refresh-bi edge function hourly via cron
- restrict view access to adminfilial and superadmin roles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4db28e18c832a9ec128a4085626b0