### PR TITLE
feat: add investimentos table and investor extratos

### DIFF
--- a/NovoSetup/scripts/direct-database-fixes.js
+++ b/NovoSetup/scripts/direct-database-fixes.js
@@ -80,10 +80,16 @@ async function directFixes() {
             role: 'superadmin'
           },
           {
-            email: 'admin@blockurb.com', 
+            email: 'admin@blockurb.com',
             password: 'Admin2024!',
             full_name: 'Administrador',
             role: 'admin'
+          },
+          {
+            email: 'investidor@blockurb.com',
+            password: 'Invest2024!',
+            full_name: 'Investidor Demo',
+            role: 'investidor'
           }
         ];
 
@@ -107,7 +113,11 @@ async function directFixes() {
                   email: user.email,
                   full_name: user.full_name,
                   role: user.role,
-                  panels: user.role === 'superadmin' ? ['superadmin', 'adminfilial'] : ['adminfilial'],
+                  panels: user.role === 'superadmin'
+                    ? ['superadmin', 'adminfilial']
+                    : user.role === 'admin'
+                    ? ['adminfilial']
+                    : ['investidor'],
                   is_active: true
                 });
                 

--- a/NovoSetup/scripts/supabase-complete-setup.js
+++ b/NovoSetup/scripts/supabase-complete-setup.js
@@ -72,6 +72,13 @@ async function completeSupabaseSetup() {
         full_name: 'Administrador Principal',
         role: 'admin',
         panels: ['adminfilial']
+      },
+      {
+        email: 'investidor@blockurb.com',
+        password: 'Invest2024!',
+        full_name: 'Investidor Demo',
+        role: 'investidor',
+        panels: ['investidor']
       }
     ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import ReportsDashboard from "./pages/admin/ReportsDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
+import InvestidorExtratosPage from "./pages/investidor/Extratos";
 import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
 
@@ -168,6 +169,7 @@ const App = () => (
             <Route path="/investidor/relatorios" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Relatórios" /></Protected>} />
             <Route path="/investidor/config" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Configurações" /></Protected>} />
             <Route path="/investidor/carteira" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Carteira" /></Protected>} />
+            <Route path="/investidor/extratos" element={<Protected allowedRoles={['investidor']}><InvestidorExtratosPage /></Protected>} />
             <Route path="/investidor/suporte" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Suporte" /></Protected>} />
 
             {/* Terrenista */}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -73,6 +73,7 @@ export const NAV: Record<string, NavItem[]> = {
   ],
   investidor: [
     { title: "Investidor", href: "/investidor", icon: "line-chart" },
+    { title: "Extratos", href: "/investidor/extratos", icon: "file-text" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
   terrenista: [

--- a/src/pages/investidor/Extratos.tsx
+++ b/src/pages/investidor/Extratos.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { DataTable, type Column } from "@/components/app/DataTable";
+import { supabase } from "@/lib/dataClient";
+
+interface Investimento {
+  id: string;
+  quota: number;
+  documento_url: string | null;
+}
+
+export default function InvestidorExtratosPage() {
+  const [rows, setRows] = useState<Investimento[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("investimentos")
+      .select("id, quota, documento_url")
+      .then(({ data }) => setRows((data as Investimento[]) ?? []));
+  }, []);
+
+  const columns: Column[] = [
+    { key: "quota", header: "Quota" },
+    {
+      key: "documento_url",
+      header: "Documento",
+      render: (row) =>
+        row.documento_url ? (
+          <a
+            href={row.documento_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Abrir
+          </a>
+        ) : (
+          ""
+        ),
+    },
+  ];
+
+  return (
+    <Protected allowedRoles={["investidor"]}>
+      <AppShell
+        menuKey="investidor"
+        breadcrumbs={[{ label: "Investidor" }, { label: "Extratos" }]}
+      >
+        <h2 className="text-xl font-semibold mb-4">Extratos</h2>
+        <DataTable columns={columns} rows={rows} pageSize={10} />
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/migrations/20250326000000_create_investimentos.sql
+++ b/supabase/migrations/20250326000000_create_investimentos.sql
@@ -1,0 +1,15 @@
+create table if not exists public.investimentos (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    quota numeric not null,
+    documento_url text,
+    created_at timestamptz not null default now()
+);
+
+create index if not exists idx_investimentos_user on public.investimentos(user_id);
+
+alter table public.investimentos enable row level security;
+
+create policy investimentos_rls on public.investimentos for all
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add investimentos table with RLS by user
- create investor extratos page listing quotas and documents
- include investor demo user in provisioning scripts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4db2fbce4832aa57d3ecf87550f58