### PR TITLE
Add filial linkage and terrenista extrato UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import ReportsDashboard from "./pages/admin/ReportsDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
+import TerrenistaExtrato from "./pages/terrenista/Extrato";
 import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
 
@@ -176,7 +177,8 @@ const App = () => (
             <Route path="/terrenista/config" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Configurações" /></Protected>} />
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
-            
+            <Route path="/terrenista/extrato" element={<Protected allowedRoles={['terrenista']}><TerrenistaExtrato /></Protected>} />
+
             {/* Debug route */}
               <Route
                 path="/debug/connection"

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -77,7 +77,7 @@ export const NAV: Record<string, NavItem[]> = {
   ],
   terrenista: [
     { title: "Terrenista", href: "/terrenista", icon: "landmark" },
-    { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
+    { title: "Extrato", href: "/terrenista/extrato", icon: "file-text" },
   ],
 };
 

--- a/src/pages/terrenista/Extrato.tsx
+++ b/src/pages/terrenista/Extrato.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { AppShell } from "@/components/shell/AppShell";
+import { Protected } from "@/components/Protected";
+import { DataTable, type Column } from "@/components/app/DataTable";
+import { Button } from "@/components/ui/button";
+import { supabase } from "@/lib/dataClient";
+
+interface Repasse {
+  id: string;
+  valor: number;
+  documento_url: string | null;
+  created_at: string;
+}
+
+export default function Extrato() {
+  const [rows, setRows] = useState<Repasse[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("repasses")
+      .select("id, valor, documento_url, created_at")
+      .order("created_at", { ascending: false })
+      .then(({ data }) => setRows(data as Repasse[] ?? []));
+  }, []);
+
+  const columns: Column[] = [
+    { key: "created_at", header: "Data" },
+    { key: "valor", header: "Valor" },
+    {
+      key: "documento",
+      header: "Documento",
+      render: (row) =>
+        row.documento_url ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const a = document.createElement("a");
+              a.href = row.documento_url!;
+              a.download = "documento";
+              a.click();
+            }}
+          >
+            Baixar
+          </Button>
+        ) : (
+          "—"
+        ),
+    },
+  ];
+
+  return (
+    <Protected allowedRoles={["terrenista"]}>
+      <AppShell menuKey="terrenista" breadcrumbs={[{ label: "Terrenista", href: "/terrenista" }, { label: "Extrato" }]}> 
+        <DataTable columns={columns} rows={rows} pageSize={5} />
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/migrations/20250401000000_add_filial_to_terrenistas_repasses.sql
+++ b/supabase/migrations/20250401000000_add_filial_to_terrenistas_repasses.sql
@@ -1,0 +1,33 @@
+-- Add filial_id FK to terrenistas and repasses and enforce RLS
+
+alter table if exists public.terrenistas
+  add column if not exists filial_id uuid references public.filiais(id) on delete cascade;
+
+create index if not exists idx_terrenistas_filial on public.terrenistas(filial_id);
+
+alter table if exists public.repasses
+  add column if not exists filial_id uuid references public.filiais(id) on delete cascade;
+
+create index if not exists idx_repasses_filial on public.repasses(filial_id);
+
+-- Ensure tables have RLS enabled
+alter table if exists public.terrenistas enable row level security;
+alter table if exists public.repasses enable row level security;
+
+-- Terrenistas: owner access only within same filial
+create policy if not exists terrenistas_owner
+  on public.terrenistas for all
+  using (user_id = auth.uid() and filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid)
+  with check (user_id = auth.uid() and filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid);
+
+-- Repasses: owner access only via terrenista relationship and filial match
+create policy if not exists repasses_owner
+  on public.repasses for all
+  using (
+    filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid
+    and terrenista_id in (select id from public.terrenistas where user_id = auth.uid())
+  )
+  with check (
+    filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid
+    and terrenista_id in (select id from public.terrenistas where user_id = auth.uid())
+  );


### PR DESCRIPTION
## Summary
- add migration linking terrenistas and repasses to filial and row-level security
- add terrenista extrato page with document download
- wire terrenista extrato route and navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4db30ff58832a882197485ae0536c