### PR TITLE
Add CNAB240 utilities and upload endpoint

### DIFF
--- a/lib/cnab.ts
+++ b/lib/cnab.ts
@@ -1,0 +1,45 @@
+export interface RemessaRegistro {
+  nossoNumero: string;
+  valor: number;
+}
+
+function pad(value: string | number, length: number, char: string = '0', side: 'left' | 'right' = 'left'): string {
+  const str = String(value);
+  if (str.length >= length) return str.slice(0, length);
+  const padStr = char.repeat(length - str.length);
+  return side === 'left' ? padStr + str : str + padStr;
+}
+
+function line(...parts: string[]): string {
+  const joined = parts.join('');
+  return joined.padEnd(240, ' ');
+}
+
+export function generateRemessa(lote: number, filial: string, registros: RemessaRegistro[] = []): string {
+  const header = line('0', pad(lote, 4), pad(filial, 10, ' ', 'right'), pad('HEADER', 230, ' ', 'right'));
+  const body = registros.map((r, idx) =>
+    line(
+      '1',
+      pad(lote, 4),
+      pad(filial, 10, ' ', 'right'),
+      pad(idx + 1, 5),
+      pad(r.nossoNumero, 20, ' ', 'right'),
+      pad(r.valor.toFixed(2).replace('.', ''), 15)
+    )
+  );
+  const trailer = line('9', pad(lote, 4), pad(filial, 10, ' ', 'right'), pad('TRAILER', 230, ' ', 'right'));
+  return [header, ...body, trailer].join('\n');
+}
+
+export function parseRetorno(content: string): { lote: number; filial: string } {
+  const firstLine = content.split(/\r?\n/)[0] || '';
+  const lote = Number(firstLine.slice(1, 5).trim());
+  const filial = firstLine.slice(5, 15).trim();
+  if (!lote || !filial) throw new Error('Invalid CNAB file');
+  return { lote, filial };
+}
+
+export function validateRetorno(content: string, lote: number, filial: string): boolean {
+  const parsed = parseRetorno(content);
+  return parsed.lote === lote && parsed.filial === filial;
+}

--- a/scripts/cnab-remessa.ts
+++ b/scripts/cnab-remessa.ts
@@ -1,0 +1,18 @@
+import { writeFileSync, readFileSync } from 'fs';
+import { generateRemessa, RemessaRegistro } from '../lib/cnab.ts';
+
+const [,, loteArg, filialArg, outFile, recordsFile] = process.argv;
+
+if (!loteArg || !filialArg || !outFile) {
+  console.error('Usage: ts-node scripts/cnab-remessa.ts <lote> <filial> <outputFile> [records.json]');
+  process.exit(1);
+}
+
+let registros: RemessaRegistro[] = [];
+if (recordsFile) {
+  registros = JSON.parse(readFileSync(recordsFile, 'utf8')) as RemessaRegistro[];
+}
+
+const content = generateRemessa(Number(loteArg), filialArg, registros);
+writeFileSync(outFile, content);
+console.log(`Arquivo CNAB gerado em ${outFile}`);

--- a/supabase/functions/upload-retorno/index.ts
+++ b/supabase/functions/upload-retorno/index.ts
@@ -1,0 +1,52 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { parseRetorno } from "../../../lib/cnab.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+    const lote = Number(form.get("lote"));
+    const filial = String(form.get("filial"));
+
+    if (!(file instanceof File) || !lote || !filial) {
+      return new Response(JSON.stringify({ error: "Invalid payload" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const content = await file.text();
+    const { lote: fileLote, filial: fileFilial } = parseRetorno(content);
+    const valid = fileLote === lote && fileFilial === filial;
+
+    return new Response(
+      JSON.stringify({ valid, lote: fileLote, filial: fileFilial }),
+      {
+        status: valid ? 200 : 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e?.message || e) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- implement CNAB240 generator and parser library
- add CLI to produce remessa files
- create return-file upload endpoint validating lote/filial

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4db1dfe08832a8e66c37608791399