### PR TITLE
feat: add commissions view and navigation

### DIFF
--- a/MANUAL_RLS_TESTS.md
+++ b/MANUAL_RLS_TESTS.md
@@ -19,4 +19,10 @@ These steps verify that row level security policies based on `filial_id` prevent
 5. **Masterplan overlays and lotes**
    - Repeat similar `select` and `insert` tests on `lotes` and `masterplan_overlays` ensuring cross-filial access is denied.
 
+6. **View vw_comissoes**
+   - Insert vendas for at least two corretores across different filiais.
+   - Authenticate as `user_a` and run `select * from vw_comissoes;`.
+   - Confirm only aggregates for `filial_a` are returned.
+   - Authenticate as `user_b` and ensure only `filial_b` rows appear.
+
 Document the observed results for future reference.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ const App = () => (
             <Route path="/super-admin/filiais-acessos" element={<Protected allowedRoles={['superadmin']}><FiliaisAccessPage /></Protected>} />
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
+            <Route path="/super-admin/comissoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Comissões" /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
@@ -101,6 +102,7 @@ const App = () => (
             <Route path="/admin-filial/mapa-interativo" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><MapaInterativo /></Protected>} />
             <Route path="/admin-filial/lotes" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><LotesPage /></Protected>} />
             <Route path="/admin-filial/lotes-vendas" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><LotesVendas /></Protected>} />
+            <Route path="/admin-filial/comissoes" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><PanelSectionPage menuKey="adminfilial" title="Admin Filial" section="Comissões" /></Protected>} />
             <Route path="/admin-filial/assinaturas" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><AssinaturasPage /></Protected>} />
             <Route path="/admin-filial/auditoria" element={<Protected allowedRoles={['adminfilial', 'superadmin']} panelKey="adminfilial"><AuditLogsFilialPage /></Protected>} />
 
@@ -155,6 +157,7 @@ const App = () => (
             <Route path="/corretor/config" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Configurações" /></Protected>} />
             <Route path="/corretor/leads" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Leads" /></Protected>} />
             <Route path="/corretor/vendas" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Vendas" /></Protected>} />
+            <Route path="/corretor/comissoes" element={<Protected allowedRoles={['corretor']}><PanelSectionPage menuKey="corretor" title="Corretor" section="Comissões" /></Protected>} />
 
             {/* Obras */}
             <Route path="/obras" element={<Protected allowedRoles={['obras']}><PanelHomePage menuKey="obras" title="Obras" /></Protected>} />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -23,7 +23,7 @@ export const NAV: Record<string, NavItem[]> = {
     { label: "Aprovação", href: "/super-admin/aprovacao", icon: "check-circle" },
     { label: "Tokenização", href: "/super-admin/tokenizacao", icon: "key" },
     { label: "Auditoria", href: "/super-admin/auditoria", icon: "file-text" },
-
+    { label: "Comissões", href: "/super-admin/comissoes", icon: "dollar-sign" },
     { label: "Relatórios", href: "/super-admin/relatorios", icon: "bar-chart-2" },
     { label: "Configurações", href: "/super-admin/config", icon: "settings" },
   ],
@@ -34,6 +34,7 @@ export const NAV: Record<string, NavItem[]> = {
     { label: "Novo Empreendimento", href: "/admin-filial/empreendimentos/novo", icon: "plus-circle", panelKey: "adminfilial" },
     { label: "Mapa Interativo", href: "/admin-filial/mapa", icon: "map", panelKey: "urbanista" },
     { label: "Vendas de Lotes", href: "/admin-filial/lotes-vendas", icon: "dollar-sign", panelKey: "comercial" },
+    { label: "Comissões", href: "/admin-filial/comissoes", icon: "dollar-sign", panelKey: "comercial" },
     { label: "Assinaturas", href: "/admin-filial/assinaturas", icon: "pen-line", panelKey: "adminfilial" },
     { label: "Auditoria", href: "/admin-filial/auditoria", icon: "file-text", panelKey: "adminfilial" },
     { label: "Relatórios", href: "/admin-filial/relatorios", icon: "chart", panelKey: "adminfilial" },
@@ -65,6 +66,7 @@ export const NAV: Record<string, NavItem[]> = {
   ],
   corretor: [
     { title: "Corretor", href: "/corretor", icon: "user" },
+    { label: "Comissões", href: "/corretor/comissoes", icon: "dollar-sign" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
   obras: [

--- a/supabase/migrations/20250401000000_create_vw_comissoes.sql
+++ b/supabase/migrations/20250401000000_create_vw_comissoes.sql
@@ -1,0 +1,19 @@
+-- View aggregating lot sales by broker and status
+-- Relies on RLS policies defined on public.lotes
+
+drop view if exists public.vw_comissoes;
+
+create view public.vw_comissoes as
+select
+  l.filial_id,
+  (l.properties->>'corretor_id')::uuid as corretor_id,
+  up.full_name as corretor_nome,
+  l.status,
+  count(*) as total_lotes,
+  coalesce(sum(coalesce(l.preco, l.valor)), 0) as valor_total
+from public.lotes l
+left join public.user_profiles up on up.user_id = (l.properties->>'corretor_id')::uuid
+where (l.properties->>'corretor_id') is not null
+group by l.filial_id, corretor_id, up.full_name, l.status;
+
+alter view public.vw_comissoes set (security_invoker = on);


### PR DESCRIPTION
## Summary
- add vw_comissoes view aggregating lot sales by broker and status
- expose Comissões links in navigation and routes
- document RLS checks for commissions view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4db278528832a9fcca82ce19f81e9