### PR TITLE
feat: add dashboard kpi components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+e2e/screenshots/

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,8 @@
+import { test } from "@playwright/test";
+import fs from "fs";
+
+test("dashboard screenshot", async ({ page }) => {
+  await page.goto("http://localhost:5173/super-admin/dashboard");
+  fs.mkdirSync("e2e/screenshots", { recursive: true });
+  await page.screenshot({ path: "e2e/screenshots/dashboard.png", fullPage: true });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.7.0",
         "@testing-library/react": "^16.3.0",
@@ -1125,6 +1126,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6697,6 +6714,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -70,6 +71,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.54.2",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: true,
+    timeout: 120000,
+    env: {
+      VITE_SUPABASE_URL: "http://localhost",
+      VITE_SUPABASE_ANON_KEY: "test",
+    },
+  },
+});

--- a/src/components/app/Heatmap.tsx
+++ b/src/components/app/Heatmap.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useFilialKpis } from "@/hooks/useFilialKpis";
+
+export function Heatmap() {
+  const mapRef = useRef<L.Map | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { data } = useFilialKpis();
+
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+    mapRef.current = L.map(containerRef.current).setView([-14.235, -51.9253], 4);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OpenStreetMap contributors",
+    }).addTo(mapRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    mapRef.current.eachLayer(layer => {
+      if ((layer as any).options?.radius) {
+        mapRef.current?.removeLayer(layer);
+      }
+    });
+    data?.forEach(kpi => {
+      if (kpi.lat && kpi.lng) {
+        L.circle([kpi.lat, kpi.lng], {
+          radius: 50000,
+          color: "red",
+          fillColor: "red",
+          fillOpacity: Math.min(0.8, kpi.vgv / 1000000),
+        }).addTo(mapRef.current!);
+      }
+    });
+  }, [data]);
+
+  return <div ref={containerRef} style={{ height: 400, width: "100%" }} />;
+}
+

--- a/src/components/app/InadimplenciaTable.tsx
+++ b/src/components/app/InadimplenciaTable.tsx
@@ -1,0 +1,26 @@
+import { useFilialKpis } from "@/hooks/useFilialKpis";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export function InadimplenciaTable() {
+  const { data } = useFilialKpis();
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Filial</TableHead>
+          <TableHead>Inadimplência (%)</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data?.map(row => (
+          <TableRow key={row.filial_id}>
+            <TableCell className="font-mono">{row.filial_id}</TableCell>
+            <TableCell>{row.inadimplencia}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+

--- a/src/components/app/VGVChart.tsx
+++ b/src/components/app/VGVChart.tsx
@@ -1,0 +1,21 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import { useFilialKpis } from "@/hooks/useFilialKpis";
+
+export function VGVChart() {
+  const { data } = useFilialKpis();
+  const chartData = data?.map(d => ({ filial: d.filial_id, vgv: d.vgv })) ?? [];
+
+  return (
+    <div style={{ width: "100%", height: 300 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData}>
+          <XAxis dataKey="filial" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="vgv" fill="#8884d8" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+

--- a/src/hooks/useFilialKpis.ts
+++ b/src/hooks/useFilialKpis.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/dataClient";
+
+export interface FilialKpi {
+  filial_id: string;
+  vgv: number;
+  inadimplencia: number;
+  lat?: number;
+  lng?: number;
+}
+
+async function fetchKpis(): Promise<FilialKpi[]> {
+  const { data, error } = await supabase.rpc("mv_kpis_filial");
+  if (error) throw error;
+  return (data as FilialKpi[]) ?? [];
+}
+
+export function useFilialKpis() {
+  return useQuery({ queryKey: ["mv_kpis_filial"], queryFn: fetchKpis });
+}
+

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -10,6 +10,10 @@ import { Building2, FileText, Target } from "lucide-react";
 import { useState } from "react";
 import { useFilterOptions } from "@/hooks/useFilterOptions";
 import { LotesMapPreview } from "@/components/app/LotesMapPreview";
+import { VGVChart } from "@/components/app/VGVChart";
+import { InadimplenciaTable } from "@/components/app/InadimplenciaTable";
+import { Heatmap } from "@/components/app/Heatmap";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const columns = [
   { key: 'nome', header: 'Nome' },
@@ -90,6 +94,36 @@ export default function AdminDashboard() {
           <div className="mt-4">
             <Button variant="outline">Abrir mapa completo</Button>
           </div>
+        </div>
+
+        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>VGV por Filial</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <VGVChart />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Inadimplência</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <InadimplenciaTable />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>Heatmap de Vendas</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Heatmap />
+            </CardContent>
+          </Card>
         </div>
       </AppShell>
     </Protected>

--- a/supabase/rpc/mv_kpis_filial.sql
+++ b/supabase/rpc/mv_kpis_filial.sql
@@ -1,0 +1,7 @@
+create or replace function mv_kpis_filial()
+returns setof mv_kpis_filial
+language sql
+security definer
+as $$
+  select * from mv_kpis_filial;
+$$;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,5 +21,6 @@ export default defineConfig(({ mode }) => ({
   },
   test: {
     environment: "jsdom",
+    exclude: ["e2e/**", "node_modules/**"],
   },
 }));


### PR DESCRIPTION
## Summary
- fetch filial KPIs through mv_kpis_filial RPC
- show VGV chart, inadimplencia table and heatmap on admin dashboard
- add Playwright e2e test to capture dashboard screenshot

## Testing
- `npm test`
- `npm run e2e` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db2aebd4832a94e332029e033bd9