### PR TITLE
feat: support shapefile conversion for lot processing

### DIFF
--- a/supabase/functions/convert-shapefile/index.ts
+++ b/supabase/functions/convert-shapefile/index.ts
@@ -1,0 +1,45 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import shp from "https://esm.sh/shpjs@4.0.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) {
+      return new Response(JSON.stringify({ error: "file required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const geojson = await shp(arrayBuffer);
+    return new Response(JSON.stringify(geojson), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("convert-shapefile error", err);
+    return new Response(JSON.stringify({ error: String(err?.message || err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `convert-shapefile` edge function that returns GeoJSON
- allow empreendimento creation page to accept shapefile uploads and convert them to GeoJSON before calling `process_geojson_lotes`

## Testing
- `npm run lint`
- `npm test`
- `node parse_shp.mjs` (convert shapefile zip to FeatureCollection using shpjs)


------
https://chatgpt.com/codex/tasks/task_e_68a4db2df990832aa01f5f976ade89a7