### PR TITLE
Add widget telemetry logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import InadimplenciaDashboard from "./pages/admin/InadimplenciaDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
+import WidgetTelemetryPage from "./pages/admin/WidgetTelemetry";
 import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
 import RenegociacoesPage from "./pages/juridico/Renegociacoes";
@@ -88,6 +89,7 @@ const App = () => (
             <Route path="/super-admin/mapa" element={<Protected allowedRoles={['superadmin']}><MapaSuperAdmin /></Protected>} />
             <Route path="/super-admin/auditoria" element={<Protected allowedRoles={['superadmin']}><AuditLogsPage /></Protected>} />
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
+            <Route path="/super-admin/widget-telemetry" element={<Protected allowedRoles={['superadmin']}><WidgetTelemetryPage /></Protected>} />
             <Route path="/super-admin/inadimplencia" element={<Protected allowedRoles={['superadmin']}><InadimplenciaDashboard /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />

--- a/src/components/public/Widget.tsx
+++ b/src/components/public/Widget.tsx
@@ -28,6 +28,15 @@ export function Widget({ empreendimentoId, height = '400px' }: WidgetProps) {
   }, []);
 
   useEffect(() => {
+    if (!empreendimentoId) return;
+    void supabase.rpc('log_widget_event', {
+      widget_id: empreendimentoId,
+      evento: 'view',
+      meta: { empreendimento_id: empreendimentoId }
+    });
+  }, [empreendimentoId]);
+
+  useEffect(() => {
     const map = mapRef.current;
     if (!map || !empreendimentoId) return;
 

--- a/src/pages/admin/WidgetTelemetry.tsx
+++ b/src/pages/admin/WidgetTelemetry.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/dataClient";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+type Row = {
+  evento: string;
+  count: number;
+};
+
+export default function WidgetTelemetryPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+
+  useEffect(() => {
+    document.title = "Widget Telemetry | BlockURB";
+    supabase
+      .from("widget_telemetry")
+      .select("evento, count:id", { group: "evento" })
+      .then(({ data }) => setRows((data as any) || []));
+  }, []);
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell menuKey="superadmin" breadcrumbs={[{ label: "Super Admin" }, { label: "Widget Telemetry" }]}> 
+        <Card>
+          <CardHeader>
+            <CardTitle>Widget Telemetry</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Evento</TableHead>
+                  <TableHead>Contagem</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map(r => (
+                  <TableRow key={r.evento}>
+                    <TableCell>{r.evento}</TableCell>
+                    <TableCell>{(r as any).count}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/migrations/20250801000000_widget_telemetry.sql
+++ b/supabase/migrations/20250801000000_widget_telemetry.sql
@@ -1,0 +1,26 @@
+-- Create table for widget telemetry
+create table if not exists public.widget_telemetry (
+  id uuid primary key default gen_random_uuid(),
+  widget_id uuid not null,
+  evento text not null,
+  meta jsonb,
+  created_at timestamptz default now()
+);
+
+-- Function to log widget events
+create or replace function public.log_widget_event(
+  widget_id uuid,
+  evento text,
+  meta jsonb
+)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.widget_telemetry(widget_id, evento, meta)
+  values (widget_id, evento, meta);
+end;
+$$;
+
+grant execute on function public.log_widget_event(uuid, text, jsonb) to anon;

--- a/supabase/rpc/log_widget_event.sql
+++ b/supabase/rpc/log_widget_event.sql
@@ -1,0 +1,14 @@
+create or replace function public.log_widget_event(
+  widget_id uuid,
+  evento text,
+  meta jsonb
+)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.widget_telemetry(widget_id, evento, meta)
+  values (widget_id, evento, meta);
+end;
+$$;


### PR DESCRIPTION
## Summary
- track widget events with new `log_widget_event` function
- log widget views from public widget
- add admin page to review aggregated widget telemetry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ddb59e3c832aadad6546636ac6e4