### PR TITLE
feat: manage doc templates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import AuditLogsPage from "./pages/admin/AuditLogs";
 import AuditLogsFilialPage from "./pages/admin/AuditLogsFilial";
 import ReportsDashboard from "./pages/admin/ReportsDashboard";
 import InadimplenciaDashboard from "./pages/admin/InadimplenciaDashboard";
+import ContratosPage from "./pages/admin/Contratos";
 import AdminDashboard from "./pages/AdminDashboard";
 import FiliaisPage from "./pages/admin/Filiais";
 import MapaRealPage from "./pages/admin/MapaReal";
@@ -91,6 +92,7 @@ const App = () => (
             <Route path="/super-admin/relatorios" element={<Protected allowedRoles={['superadmin']}><ReportsDashboard /></Protected>} />
             <Route path="/super-admin/widget-telemetry" element={<Protected allowedRoles={['superadmin']}><WidgetTelemetryPage /></Protected>} />
             <Route path="/super-admin/inadimplencia" element={<Protected allowedRoles={['superadmin']}><InadimplenciaDashboard /></Protected>} />
+            <Route path="/super-admin/contratos" element={<Protected allowedRoles={['superadmin']}><ContratosPage /></Protected>} />
             <Route path="/super-admin/config" element={<Protected allowedRoles={['superadmin']}><ConfigPage /></Protected>} />
             <Route path="/super-admin/organizacoes" element={<Protected allowedRoles={['superadmin']}><PanelSectionPage menuKey="superadmin" title="Super Admin" section="Organizações" /></Protected>} />
             <Route path="/super-admin/usuarios" element={<Protected allowedRoles={['superadmin']}><UsuariosPage /></Protected>} />

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -22,6 +22,7 @@ export const NAV: Record<string, NavItem[]> = {
     { label: "Usuários", href: "/super-admin/usuarios", icon: "user" },
     { label: "Aprovação", href: "/super-admin/aprovacao", icon: "check-circle" },
     { label: "Tokenização", href: "/super-admin/tokenizacao", icon: "key" },
+    { label: "Contratos", href: "/super-admin/contratos", icon: "file-text" },
     { label: "Auditoria", href: "/super-admin/auditoria", icon: "file-text" },
 
     { label: "Relatórios", href: "/super-admin/relatorios", icon: "bar-chart-2" },

--- a/src/pages/admin/Contratos.tsx
+++ b/src/pages/admin/Contratos.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { Protected } from "@/components/Protected";
+import { AppShell } from "@/components/shell/AppShell";
+import { supabase } from "@/lib/dataClient";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { DataTable, Column } from "@/components/app/DataTable";
+import { toast } from "sonner";
+
+interface DocTemplate {
+  id: string;
+  name: string;
+  storage_path: string;
+}
+
+export default function ContratosPage() {
+  const [templates, setTemplates] = useState<DocTemplate[]>([]);
+  const [name, setName] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const { data, error } = await supabase
+      .from("doc_templates")
+      .select("id, name, storage_path")
+      .order("name");
+    if (error) toast.error("Erro ao carregar templates: " + error.message);
+    setTemplates(data || []);
+  }
+
+  async function handleUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file) { toast.error("Selecione um arquivo DOCX"); return; }
+    if (!name.trim()) { toast.error("Informe o nome"); return; }
+    setLoading(true);
+    try {
+      const path = `${Date.now()}-${file.name.replace(/\s/g, '_')}`;
+      const { error: upErr } = await supabase.storage.from("doc-templates").upload(path, file);
+      if (upErr) throw upErr;
+      const { error: insErr } = await supabase.from("doc_templates").insert({ name: name.trim(), storage_path: path });
+      if (insErr) throw insErr;
+      toast.success("Template enviado");
+      setName("");
+      setFile(null);
+      load();
+    } catch (err: any) {
+      toast.error("Falha no upload: " + err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const columns: Column[] = [
+    { key: "name", header: "Nome" },
+    { key: "storage_path", header: "Arquivo" },
+  ];
+
+  const rows = templates.map((t) => ({ id: t.id, name: t.name, storage_path: t.storage_path }));
+
+  return (
+    <Protected allowedRoles={["superadmin"]}>
+      <AppShell
+        menuKey="superadmin"
+        breadcrumbs={[{ label: "Super Admin", href: "/super-admin" }, { label: "Contratos" }]}
+      >
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Novo Template</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nome" />
+              <Input type="file" accept=".docx" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+              <Button onClick={handleUpload} disabled={loading}>Upload</Button>
+            </CardContent>
+          </Card>
+
+          <Card className="md:col-span-2">
+            <CardHeader>
+              <CardTitle>Templates</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DataTable columns={columns} rows={rows} pageSize={5} />
+            </CardContent>
+          </Card>
+        </div>
+      </AppShell>
+    </Protected>
+  );
+}

--- a/supabase/functions/render-docx/index.ts
+++ b/supabase/functions/render-docx/index.ts
@@ -1,0 +1,46 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+
+// Bundle Node-based docx libraries using Deno.emit
+const { files } = await Deno.emit("/doc.ts", {
+  bundle: "module",
+  sources: {
+    "/doc.ts": `import PizZip from "npm:pizzip";
+import Docxtemplater from "npm:docxtemplater";
+export function render(template, data) {
+  const zip = new PizZip(template);
+  const doc = new Docxtemplater(zip, { paragraphLoop: true, linebreaks: true });
+  doc.render(data);
+  return doc.getZip().generate({ type: "uint8array" });
+}
+`,
+  },
+});
+
+const code = Object.values(files)[0] as string;
+const { render } = await import("data:application/javascript," + encodeURIComponent(code));
+
+function b64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+serve(async (req) => {
+  try {
+    const { template, data } = await req.json();
+    const templateBytes = b64ToUint8(template);
+    const rendered = render(templateBytes, data);
+    return new Response(rendered, {
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20250802000000_create_doc_templates.sql
+++ b/supabase/migrations/20250802000000_create_doc_templates.sql
@@ -1,0 +1,14 @@
+create table if not exists public.doc_templates (
+    id uuid primary key default gen_random_uuid(),
+    filial_id uuid references public.filiais(id) on delete cascade,
+    name text not null,
+    storage_path text not null,
+    created_at timestamp with time zone default now()
+);
+
+create index if not exists idx_doc_templates_filial on public.doc_templates(filial_id);
+
+alter table public.doc_templates enable row level security;
+create policy doc_templates_filial_policy on public.doc_templates
+  using (filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid)
+  with check (filial_id = current_setting('request.jwt.claims.filial_id', true)::uuid);


### PR DESCRIPTION
## Summary
- add render-docx edge function bundling docx libs via Deno.emit
- create doc_templates table and RLS policy
- UI for uploading and listing templates in super-admin panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dee99390832a9247b38bc86d2f37