### PR TITLE
feat: add CNAB 240 utilities

### DIFF
--- a/lib/cnab.ts
+++ b/lib/cnab.ts
@@ -1,0 +1,36 @@
+export interface RemessaOptions {
+  lote: number;
+  filial: string;
+  records?: string[];
+}
+
+function formatLine(content: string): string {
+  return content.padEnd(240).slice(0, 240);
+}
+
+export function generateRemessa(
+  lote: number,
+  filial: string,
+  records: string[] = [],
+): string {
+  const header = formatLine(
+    `0${lote.toString().padStart(4, '0')}${filial.padEnd(10).slice(0, 10)}`,
+  );
+
+  const body = records.map((r) => formatLine(r));
+
+  const trailer = formatLine(
+    `9${lote.toString().padStart(4, '0')}${records.length
+      .toString()
+      .padStart(6, '0')}`,
+  );
+
+  return [header, ...body, trailer].join('\n');
+}
+
+export function parseRetorno(content: string): { lote: number; filial: string } {
+  const [firstLine] = content.split(/\r?\n/);
+  const lote = Number(firstLine?.slice(1, 5)) || 0;
+  const filial = firstLine?.slice(5, 15).trim() || '';
+  return { lote, filial };
+}

--- a/scripts/cnab-remessa.ts
+++ b/scripts/cnab-remessa.ts
@@ -1,0 +1,14 @@
+import { writeFileSync } from 'fs';
+import { generateRemessa } from '../lib/cnab.ts';
+
+const [,, loteArg, filial, output] = process.argv;
+
+if (!loteArg || !filial || !output) {
+  console.error('Usage: node scripts/cnab-remessa.ts <lote> <filial> <output>');
+  process.exit(1);
+}
+
+const lote = Number(loteArg);
+const fileContent = generateRemessa(lote, filial);
+writeFileSync(output, fileContent, { encoding: 'utf8' });
+console.log(`Remessa gerada em ${output}`);

--- a/supabase/functions/upload-retorno/index.ts
+++ b/supabase/functions/upload-retorno/index.ts
@@ -1,0 +1,38 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { parseRetorno } from "../../../lib/cnab.ts";
+
+serve(async (req: Request) => {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const form = await req.formData();
+  const file = form.get("file");
+  const filial = form.get("filial");
+  const loteExpected = Number(form.get("lote"));
+
+  if (!(file instanceof File) || typeof filial !== "string" || isNaN(loteExpected)) {
+    return new Response(
+      JSON.stringify({ error: "file, lote and filial are required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const content = await file.text();
+  const info = parseRetorno(content);
+
+  if (info.filial !== filial || info.lote !== loteExpected) {
+    return new Response(
+      JSON.stringify({
+        error: "validation failed",
+        parsed: info,
+        expected: { lote: loteExpected, filial },
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  return new Response(JSON.stringify(info), {
+    headers: { "Content-Type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- add CNAB 240 helper library with remessa generation and retorno parsing
- provide `cnab-remessa` CLI to write remessa files
- create `upload-retorno` edge function validating lote and filial

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e250cf5c832aa12aa27908c36c6b