### PR TITLE
Add investimentos table and investor extratos page

### DIFF
--- a/NovoSetup/scripts/direct-database-fixes.js
+++ b/NovoSetup/scripts/direct-database-fixes.js
@@ -77,13 +77,22 @@ async function directFixes() {
             email: 'superadmin@blockurb.com',
             password: 'BlockUrb2024!',
             full_name: 'Super Administrador',
-            role: 'superadmin'
+            role: 'superadmin',
+            panels: ['superadmin', 'adminfilial', 'cliente']
           },
           {
-            email: 'admin@blockurb.com', 
+            email: 'admin@blockurb.com',
             password: 'Admin2024!',
             full_name: 'Administrador',
-            role: 'admin'
+            role: 'admin',
+            panels: ['adminfilial']
+          },
+          {
+            email: 'investidor@blockurb.com',
+            password: 'Invest2024!',
+            full_name: 'Investidor Demo',
+            role: 'investidor',
+            panels: ['investidor']
           }
         ];
 
@@ -101,15 +110,15 @@ async function directFixes() {
               console.log(`✅ ${user.email} criado/verificado`);
               
               // Tentar criar perfil
-              if (authData?.user) {
-                const { error: profileError } = await supabase.from('user_profiles').upsert({
-                  user_id: authData.user.id,
-                  email: user.email,
-                  full_name: user.full_name,
-                  role: user.role,
-                  panels: user.role === 'superadmin' ? ['superadmin', 'adminfilial', 'cliente'] : ['adminfilial'],
-                  is_active: true
-                });
+                if (authData?.user) {
+                  const { error: profileError } = await supabase.from('user_profiles').upsert({
+                    user_id: authData.user.id,
+                    email: user.email,
+                    full_name: user.full_name,
+                    role: user.role,
+                    panels: user.panels,
+                    is_active: true
+                  });
                 
                 if (!profileError) {
                   console.log(`✅ Perfil criado para ${user.email}`);

--- a/NovoSetup/scripts/supabase-complete-setup.js
+++ b/NovoSetup/scripts/supabase-complete-setup.js
@@ -72,6 +72,13 @@ async function completeSupabaseSetup() {
         full_name: 'Administrador Principal',
         role: 'admin',
         panels: ['adminfilial']
+      },
+      {
+        email: 'investidor@blockurb.com',
+        password: 'Invest2024!',
+        full_name: 'Investidor Demo',
+        role: 'investidor',
+        panels: ['investidor']
       }
     ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
 import RenegociacoesPage from "./pages/juridico/Renegociacoes";
 import ClienteCobrancasPage from "./pages/cliente/Cobrancas";
+import InvestidorExtratosPage from "./pages/investidor/Extratos";
 
 const queryClient = new QueryClient();
 
@@ -184,6 +185,7 @@ const App = () => (
             <Route path="/investidor" element={<Protected allowedRoles={['investidor']}><PanelHomePage menuKey="investidor" title="Investidor" /></Protected>} />
             <Route path="/investidor/relatorios" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Relatórios" /></Protected>} />
             <Route path="/investidor/config" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Configurações" /></Protected>} />
+            <Route path="/investidor/extratos" element={<Protected allowedRoles={['investidor']}><InvestidorExtratosPage /></Protected>} />
             <Route path="/investidor/carteira" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Carteira" /></Protected>} />
             <Route path="/investidor/suporte" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Suporte" /></Protected>} />
 

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -77,6 +77,7 @@ export const NAV: Record<string, NavItem[]> = {
   ],
   investidor: [
     { title: "Investidor", href: "/investidor", icon: "line-chart" },
+    { title: "Extratos", href: "/investidor/extratos", icon: "file-text" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
   terrenista: [

--- a/src/pages/investidor/Extratos.tsx
+++ b/src/pages/investidor/Extratos.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { AppShell } from "@/components/shell/AppShell";
+import { DataTable, type Column } from "@/components/app/DataTable";
+import { supabase } from "@/lib/dataClient";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function InvestidorExtratosPage() {
+  const { user } = useAuth();
+  const [rows, setRows] = useState<Record<string, any>[]>([]);
+  const [columns, setColumns] = useState<Column[]>([]);
+
+  useEffect(() => {
+    if (!user) return;
+    supabase
+      .from("investimentos")
+      .select("quota, doc_url")
+      .eq("user_id", user.id)
+      .then(({ data }) => {
+        setRows(data ?? []);
+        if (data && data.length > 0) {
+          setColumns(Object.keys(data[0]).map(key => ({ key, header: key })));
+        }
+      });
+  }, [user]);
+
+  return (
+    <AppShell
+      menuKey="investidor"
+      breadcrumbs={[{ label: "Investidor", href: "/investidor" }, { label: "Extratos" }]}
+    >
+      <DataTable columns={columns} rows={rows} pageSize={5} />
+    </AppShell>
+  );
+}

--- a/supabase/migrations/20250805000000_create_investimentos.sql
+++ b/supabase/migrations/20250805000000_create_investimentos.sql
@@ -1,0 +1,15 @@
+create table if not exists public.investimentos (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    quota numeric not null,
+    doc_url text,
+    created_at timestamptz default now()
+);
+
+create index if not exists idx_investimentos_user on public.investimentos(user_id);
+
+alter table public.investimentos enable row level security;
+
+create policy investimentos_rls on public.investimentos for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- create investimentos table with RLS enforced by user_id
- add investor extratos page and route listing quotas and docs
- provision default investidor user in setup scripts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4e521c920832a90a0d9da5f98bc9d