### PR TITLE
Add terrenista repasses tables and extrato UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { publicWidgetEnabled } from "@/config/publicWidget";
 import RenegociacoesPage from "./pages/juridico/Renegociacoes";
 import ClienteCobrancasPage from "./pages/cliente/Cobrancas";
 import InvestidorExtratosPage from "./pages/investidor/Extratos";
+import TerrenistaExtratosPage from "./pages/terrenista/Extratos";
 
 const queryClient = new QueryClient();
 
@@ -193,6 +194,7 @@ const App = () => (
             <Route path="/terrenista" element={<Protected allowedRoles={['terrenista']}><PanelHomePage menuKey="terrenista" title="Terrenista" /></Protected>} />
             <Route path="/terrenista/relatorios" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Relatórios" /></Protected>} />
             <Route path="/terrenista/config" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Configurações" /></Protected>} />
+            <Route path="/terrenista/extratos" element={<Protected allowedRoles={['terrenista']}><TerrenistaExtratosPage /></Protected>} />
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
 

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -82,6 +82,7 @@ export const NAV: Record<string, NavItem[]> = {
   ],
   terrenista: [
     { title: "Terrenista", href: "/terrenista", icon: "landmark" },
+    { title: "Extratos", href: "/terrenista/extratos", icon: "file-text" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
   cliente: [

--- a/supabase/migrations/20250901000000_create_terrenistas_repasses.sql
+++ b/supabase/migrations/20250901000000_create_terrenistas_repasses.sql
@@ -1,0 +1,43 @@
+create table if not exists public.terrenistas (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references auth.users(id) on delete cascade,
+    filial_id uuid not null references public.filiais(id) on delete cascade,
+    created_at timestamptz default now()
+);
+
+create index if not exists idx_terrenistas_user on public.terrenistas(user_id);
+create index if not exists idx_terrenistas_filial on public.terrenistas(filial_id);
+
+alter table public.terrenistas enable row level security;
+
+create policy terrenistas_rls on public.terrenistas for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create table if not exists public.repasses (
+    id uuid primary key default gen_random_uuid(),
+    terrenista_id uuid not null references public.terrenistas(id) on delete cascade,
+    filial_id uuid not null references public.filiais(id) on delete cascade,
+    valor numeric not null,
+    doc_url text,
+    created_at timestamptz default now()
+);
+
+create index if not exists idx_repasses_terrenista on public.repasses(terrenista_id);
+create index if not exists idx_repasses_filial on public.repasses(filial_id);
+
+alter table public.repasses enable row level security;
+
+create policy repasses_rls on public.repasses for all
+  using (
+    exists (
+      select 1 from public.terrenistas t
+      where t.id = terrenista_id and t.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.terrenistas t
+      where t.id = terrenista_id and t.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add terrenistas and repasses tables with filial link and owner-only RLS
- show extratos with document downloads for terrenistas and investors
- expose new terrenista extratos route and navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6dd6aa8832a8d619a7429d1078f