### PR TITLE
refactor: add env assertions

### DIFF
--- a/src/lib/__tests__/dataClient.test.ts
+++ b/src/lib/__tests__/dataClient.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('dataClient env variables', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('throws error when env vars are missing', async () => {
+    vi.resetModules()
+    vi.stubEnv('DEV', 'true')
+    vi.stubEnv('MODE', 'development')
+    vi.stubEnv('VITE_SUPABASE_URL', '')
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '')
+
+    await expect(import('../dataClient')).rejects.toThrowError()
+  })
+})
+

--- a/src/lib/dataClient.ts
+++ b/src/lib/dataClient.ts
@@ -1,12 +1,9 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
-
 const isDev = import.meta.env.DEV
 const isTest = import.meta.env.MODE === 'test'
 
-function assertEnv(value: string | undefined, name: string) {
+function assertEnv(value: string | undefined, name: string): asserts value is string {
   if (!value) {
     const msg = `❌ ${name} não definida: adicione-a ao arquivo .env.local na raiz do projeto ou configure a variável de ambiente em produção.`
     if (isDev && !isTest) {
@@ -17,7 +14,10 @@ function assertEnv(value: string | undefined, name: string) {
   }
 }
 
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 assertEnv(supabaseUrl, 'VITE_SUPABASE_URL')
+
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 assertEnv(supabaseAnonKey, 'VITE_SUPABASE_ANON_KEY')
 
 export const supabase =


### PR DESCRIPTION
## Summary
- use TypeScript assertion to validate env vars
- cover missing env vars with test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb70dba0832aaf383806782a70e3