### PR TITLE
refactor: add typed properties to geojson utils

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2,12 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { supabase } from '@/lib/dataClient';
-import { LoteData, getLoteStyle, formatArea, formatPrice } from '@/lib/geojsonUtils';
+import { LoteData, LoteProperties, getLoteStyle, formatArea, formatPrice } from '@/lib/geojsonUtils';
 
 interface MapViewProps {
   empreendimentoId?: string;
   height?: string;
-  onLoteClick?: (lote: LoteData) => void;
+  onLoteClick?: (lote: LoteData<LoteProperties>) => void;
   showControls?: boolean;
   readonly?: boolean;
   onUpdateLoteStatus?: (loteId: string, newStatus: string) => Promise<void> | void;
@@ -23,7 +23,7 @@ export function MapView({
 }: MapViewProps) {
   const mapRef = useRef<L.Map | null>(null);
   const mapContainerRef = useRef<HTMLDivElement>(null);
-  const [lotes, setLotes] = useState<LoteData[]>([]);
+  const [lotes, setLotes] = useState<LoteData<LoteProperties>[]>([]);
   const [selectedLote, setSelectedLote] = useState<string | null>(null);
   const [hoveredLote, setHoveredLote] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -111,7 +111,7 @@ export function MapView({
   }, [empreendimentoId]);
 
   // Renderizar lotes no mapa
-  const renderLotes = (lotesData: LoteData[]) => {
+  const renderLotes = (lotesData: LoteData<LoteProperties>[]) => {
     if (!mapRef.current) return;
 
     // Limpar layers existentes

--- a/src/pages/admin/EmpreendimentoNovo.tsx
+++ b/src/pages/admin/EmpreendimentoNovo.tsx
@@ -10,7 +10,7 @@ import { supabase } from "@/lib/dataClient";
 import { toast } from "sonner";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuthorization } from "@/hooks/useAuthorization";
-import { processGeoJSON, LoteData } from "@/lib/geojsonUtils";
+import { processGeoJSON, LoteData, LoteProperties } from "@/lib/geojsonUtils";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
@@ -35,7 +35,7 @@ export default function EmpreendimentoNovo() {
   const [geojsonFile, setGeojsonFile] = useState<File | null>(null);
   const [masterplanFile, setMasterplanFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
-  const [processedLotes, setProcessedLotes] = useState<LoteData[]>([]);
+  const [processedLotes, setProcessedLotes] = useState<LoteData<LoteProperties>[]>([]);
 
   const mapRef = useRef<L.Map | null>(null);
   const previewLayerRef = useRef<L.Layer | null>(null);

--- a/src/pages/admin/MapaInterativo.tsx
+++ b/src/pages/admin/MapaInterativo.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { MapView } from "@/components/MapView";
 import { supabase } from "@/lib/dataClient";
-import { LoteData } from "@/lib/geojsonUtils";
+import { LoteData, LoteProperties } from "@/lib/geojsonUtils";
 import { RefreshCw, Search, TrendingUp } from "lucide-react";
 
 interface Empreendimento {
@@ -38,7 +38,7 @@ export default function MapaInterativo() {
   const [empreendimentos, setEmpreendimentos] = useState<Empreendimento[]>([]);
   const [selectedEmp, setSelectedEmp] = useState<string>('');
   const [loading, setLoading] = useState(true);
-  const [selectedLote, setSelectedLote] = useState<LoteData | null>(null);
+  const [selectedLote, setSelectedLote] = useState<LoteData<LoteProperties> | null>(null);
   const [stats, setStats] = useState<VendasStats | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [params] = useSearchParams();
@@ -102,7 +102,7 @@ export default function MapaInterativo() {
     }
   }, [selectedEmp]);
 
-  const handleLoteClick = (lote: LoteData) => {
+  const handleLoteClick = (lote: LoteData<LoteProperties>) => {
     setSelectedLote(lote);
   };
 


### PR DESCRIPTION
## Summary
- add `LoteProperties` interface and generics to replace `any`
- propagate typed properties to consumers of `geojsonUtils`
- document recognized GeoJSON property fields

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4eb7260c0832a8dee6492cc8983a0