### PR TITLE
Use geodesic polygon area with Turf

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ npm run dev
 
 **Edit a file directly in GitHub**
 
+## Cálculo de área geodésica
+
+A função `calculatePolygonArea` agora utiliza [Turf.js](https://turfjs.org/) para obter a área geodésica dos polígonos com maior precisão. Um quadrado de 100 m no equador, por exemplo, é estimado como aproximadamente 9 977,66 m².
+
 - Navigate to the desired file(s).
 - Click the "Edit" button (pencil icon) at the top right of the file view.
 - Make your changes and commit the changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@supabase/supabase-js": "^2.55.0",
         "@tanstack/react-query": "^5.83.0",
+        "@turf/area": "^7.2.0",
+        "@turf/helpers": "^7.2.0",
         "@types/leaflet-draw": "^1.0.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3167,6 +3169,47 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.2.0.tgz",
+      "integrity": "sha512-zuTTdQ4eoTI9nSSjerIy4QwgvxqwJVciQJ8tOPuMHbXJ9N/dNjI7bU8tasjhxas/Cx3NE9NxVHtNpYHL0FSzoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/aria-query": {
@@ -8056,9 +8099,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-query": "^5.83.0",
+    "@turf/area": "^7.2.0",
+    "@turf/helpers": "^7.2.0",
     "@types/leaflet-draw": "^1.0.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/lib/__tests__/geojsonUtils.test.ts
+++ b/src/lib/__tests__/geojsonUtils.test.ts
@@ -6,9 +6,22 @@ describe('geojsonUtils', () => {
   const fc = mockFeatureCollection();
   const polygon = fc.features[0].geometry.coordinates;
 
-  it('calculatePolygonArea returns 0 for provided polygon', () => {
-    const area = calculatePolygonArea(polygon as any);
-    expect(area).toBe(0);
+  it('calculatePolygonArea retorna área geodésica para o polígono fornecido', () => {
+    const areaValue = calculatePolygonArea(polygon as any);
+    expect(areaValue).toBeCloseTo(11334.76, 2);
+  });
+
+  it('calculatePolygonArea coincide com área conhecida de quadrado de 100m no equador', () => {
+    const delta = 100 / 111319.49079327357;
+    const square = [[[0, 0], [delta, 0], [delta, delta], [0, delta], [0, 0]]];
+    const areaValue = calculatePolygonArea(square as any);
+    expect(areaValue).toBeCloseTo(9977.66, 2);
+  });
+
+  it('calculatePolygonArea coincide com área conhecida de quadrado de 1° no equador', () => {
+    const squareDeg = [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]];
+    const areaValue = calculatePolygonArea(squareDeg as any);
+    expect(areaValue).toBeCloseTo(12363718145.18, 0);
   });
 
   it('calculatePolygonCenter computes centroid', () => {
@@ -26,7 +39,7 @@ describe('geojsonUtils', () => {
       properties: fc.features[0].properties,
       status: 'disponivel'
     });
-    expect(result.lotes[0].area_m2).toBe(calculatePolygonArea(polygon as any));
+    expect(result.lotes[0].area_m2).toBeCloseTo(calculatePolygonArea(polygon as any), 2);
     expect(result.lotes[0].coordenadas).toEqual(calculatePolygonCenter(polygon as any));
     expect(result.bounds).toEqual({
       sw: { lat: -23.5485, lng: -46.639 },

--- a/src/lib/geojsonUtils.ts
+++ b/src/lib/geojsonUtils.ts
@@ -52,23 +52,23 @@ export interface ProcessedGeoJSON<P extends LoteProperties = LoteProperties> {
   };
 }
 
+import area from '@turf/area';
+import { polygon } from '@turf/helpers';
+
 /**
- * Calcula a área de um polígono usando a fórmula do shoelace
+ * Calcula a área geodésica de um polígono em metros quadrados.
  */
-export function calculatePolygonArea(coordinates: number[][]): number {
-  if (!coordinates || coordinates.length < 3) return 0;
-  
-  let area = 0;
-  const coords = coordinates[0] || coordinates; // Primeiro ring (exterior)
-  
-  for (let i = 0; i < coords.length - 1; i++) {
-    const [lng1, lat1] = coords[i];
-    const [lng2, lat2] = coords[i + 1];
-    area += (lng1 * lat2 - lng2 * lat1);
-  }
-  
-  // Converte para metros quadrados (aproximação)
-  return Math.abs(area) * 111319.9 * 111319.9 / 2;
+export function calculatePolygonArea(
+  coordinates: number[][][] | number[][]
+): number {
+  const ring = Array.isArray((coordinates as any)[0][0])
+    ? (coordinates as number[][][])[0]
+    : (coordinates as number[][]);
+
+  if (!ring || ring.length < 3) return 0;
+
+  const poly = polygon([ring] as any);
+  return area(poly);
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace manual shoelace area with Turf.js geodesic calculation
- add tests validating area for known polygons
- document new polygon area precision in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4edc4b994832ab32d39481bb28d0a