### PR TITLE
refactor: fetch filter options concurrently

### DIFF
--- a/src/hooks/useFilterOptions.ts
+++ b/src/hooks/useFilterOptions.ts
@@ -9,40 +9,76 @@ interface Empreendimento {
 /**
  * Fetches empreendimentos and distinct lote statuses from Supabase
  */
+interface FilterErrors {
+  empreendimentos: string | null;
+  statuses: string | null;
+}
+
 export function useFilterOptions() {
   const [empreendimentos, setEmpreendimentos] = useState<Empreendimento[]>([]);
   const [statuses, setStatuses] = useState<string[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<FilterErrors>({
+    empreendimentos: null,
+    statuses: null,
+  });
 
   useEffect(() => {
-    supabase
-      .from('empreendimentos')
-      .select('id, nome')
-      .order('nome')
-      .then(({ data, error }) => {
-        if (error) {
-          setError(error.message || 'Erro ao carregar empreendimentos');
-          return;
-        }
-        if (data) setEmpreendimentos(data);
-      });
+    const controller = new AbortController();
+    let isMounted = true;
 
-    supabase
-      .from('lotes')
-      .select('status')
-      .then(({ data, error }) => {
-        if (error) {
-          setError(error.message || 'Erro ao carregar statuses');
-          return;
+    async function load() {
+      try {
+        const [empResult, statusResult] = await Promise.all([
+          supabase
+            .from('empreendimentos')
+            .select('id, nome')
+            .order('nome')
+            .abortSignal(controller.signal),
+          supabase
+            .from('lotes')
+            .select('status')
+            .abortSignal(controller.signal),
+        ]);
+
+        if (!isMounted) return;
+
+        if (empResult.error) {
+          setErrors(prev => ({
+            ...prev,
+            empreendimentos:
+              empResult.error.message || 'Erro ao carregar empreendimentos',
+          }));
+        } else if (empResult.data) {
+          setEmpreendimentos(empResult.data);
         }
-        if (data) {
-          const unique = Array.from(new Set(data.map(d => d.status).filter(Boolean)));
+
+        if (statusResult.error) {
+          setErrors(prev => ({
+            ...prev,
+            statuses: statusResult.error.message || 'Erro ao carregar statuses',
+          }));
+        } else if (statusResult.data) {
+          const unique = Array.from(
+            new Set(statusResult.data.map(d => d.status).filter(Boolean)),
+          );
           setStatuses(unique as string[]);
         }
-      });
+      } catch (err) {
+        if (!isMounted || (err as DOMException).name === 'AbortError') return;
+        const message = (err as Error).message || 'Erro ao carregar dados';
+        setErrors({ empreendimentos: message, statuses: message });
+      }
+    }
+
+    load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
   }, []);
 
-  return { empreendimentos, statuses, error };
+  return { empreendimentos, statuses, errors };
 }
 
 export type { Empreendimento };


### PR DESCRIPTION
## Summary
- fetch empreendimentos and lot statuses concurrently with `Promise.all`
- surface separate errors for each query and cancel on unmount using `AbortController`

## Testing
- `npm test`
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a4f2405cc4832aa68c0676f05bdae2