### PR TITLE
refactor authorization profile loading

### DIFF
--- a/src/providers/AuthorizationProvider.tsx
+++ b/src/providers/AuthorizationProvider.tsx
@@ -1,8 +1,7 @@
 import { createContext, useEffect, useMemo, useState } from 'react';
-import { supabase } from '@/lib/dataClient';
 import { useAuth } from '@/hooks/useAuth';
-import type { PostgrestSingleResponse } from '@supabase/supabase-js';
 import { AuthorizationProfile } from '@/types';
+import { loadAuthorizationProfile } from './loadAuthorizationProfile';
 export type { AuthorizationProfile } from '@/types';
 
 interface AuthorizationState {
@@ -18,6 +17,7 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const controller = new AbortController();
     const load = async () => {
       if (authLoading || !user) {
         setProfile(null);
@@ -26,34 +26,7 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
       }
       setLoading(true);
       try {
-        let data: AuthorizationProfile | null = null;
-
-        // Primeiro tenta via RPC que ignora RLS
-        try {
-          const res: PostgrestSingleResponse<AuthorizationProfile> = await supabase
-            .rpc('get_my_profile')
-            .maybeSingle();
-          data = res.data;
-          if (res.error) {
-            console.error('Erro ao chamar get_my_profile:', res.error);
-          }
-        } catch (rpcErr) {
-          console.error('Erro ao chamar get_my_profile:', rpcErr);
-        }
-
-        // Se a RPC falhar ou não retornar dados, busca direto na tabela
-        if (!data) {
-          const { data: fallback, error: fbErr }: PostgrestSingleResponse<AuthorizationProfile> = await supabase
-            .from<AuthorizationProfile>('user_profiles')
-            .select('role, panels, filial_id')
-            .eq('user_id', user.id)
-            .maybeSingle();
-          data = fallback;
-          if (fbErr) {
-            console.error('Erro ao buscar user_profiles:', fbErr);
-          }
-        }
-
+        const data = await loadAuthorizationProfile(user.id, controller.signal);
         if (data) {
           setProfile({
             role: data.role ?? user.app_metadata?.role ?? 'user',
@@ -67,18 +40,21 @@ export function AuthorizationProvider({ children }: { children: React.ReactNode 
             filial_id: null,
           });
         }
-      } catch (err) {
-        console.error('Erro inesperado ao obter perfil:', err);
-        setProfile({
-          role: user.app_metadata?.role || 'user',
-          panels: [],
-          filial_id: null,
-        });
+      } catch (err: any) {
+        if (err?.name !== 'AbortError') {
+          console.error('Erro inesperado ao obter perfil:', err);
+          setProfile({
+            role: user.app_metadata?.role || 'user',
+            panels: [],
+            filial_id: null,
+          });
+        }
       } finally {
         setLoading(false);
       }
     };
     load();
+    return () => controller.abort();
   }, [user, authLoading]);
 
   const value = useMemo(() => ({ profile, loading }), [profile, loading]);

--- a/src/providers/loadAuthorizationProfile.test.ts
+++ b/src/providers/loadAuthorizationProfile.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadAuthorizationProfile } from './loadAuthorizationProfile';
+
+const mockRpc = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/dataClient', () => ({
+  supabase: {
+    rpc: (...args: any[]) => mockRpc(...args),
+    from: (...args: any[]) => mockFrom(...args),
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('loadAuthorizationProfile', () => {
+  const userId = '123';
+
+  it('utiliza fallback quando RPC falha', async () => {
+    mockRpc.mockReturnValue({
+      maybeSingle: () =>
+        Promise.resolve({ data: null, error: new Error('rpc fail') }),
+    });
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({
+              data: { role: 'admin', panels: ['dash'], filial_id: 1 },
+              error: null,
+            }),
+        }),
+      }),
+    });
+
+    const controller = new AbortController();
+    const result = await loadAuthorizationProfile(userId, controller.signal);
+    expect(result).toEqual({ role: 'admin', panels: ['dash'], filial_id: 1 });
+    expect(mockRpc).toHaveBeenCalled();
+    expect(mockFrom).toHaveBeenCalled();
+  });
+
+  it('retorna null quando RPC e fallback falham', async () => {
+    mockRpc.mockReturnValue({
+      maybeSingle: () =>
+        Promise.resolve({ data: null, error: new Error('rpc fail') }),
+    });
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () =>
+            Promise.resolve({ data: null, error: new Error('fb fail') }),
+        }),
+      }),
+    });
+
+    const controller = new AbortController();
+    const result = await loadAuthorizationProfile(userId, controller.signal);
+    expect(result).toBeNull();
+  });
+});

--- a/src/providers/loadAuthorizationProfile.ts
+++ b/src/providers/loadAuthorizationProfile.ts
@@ -1,0 +1,48 @@
+import { supabase } from '@/lib/dataClient';
+import type { AuthorizationProfile } from '@/types';
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+
+/**
+ * Carrega o perfil de autorização do usuário usando RPC com fallback para consulta direta.
+ * @param userId ID do usuário a ser buscado
+ * @param signal Abort signal para cancelar requisições em andamento
+ */
+export async function loadAuthorizationProfile(
+  userId: string,
+  signal: AbortSignal
+): Promise<AuthorizationProfile | null> {
+  const rpcPromise = supabase
+    .rpc('get_my_profile', {}, { signal })
+    .maybeSingle<AuthorizationProfile>();
+
+  const tablePromise = supabase
+    .from<AuthorizationProfile>('user_profiles')
+    .select('role, panels, filial_id', { signal })
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  const [rpcResult, tableResult] = await Promise.allSettled([
+    rpcPromise,
+    tablePromise,
+  ]);
+
+  const resolveResult = (
+    result: PromiseSettledResult<PostgrestSingleResponse<AuthorizationProfile>>,
+    context: string
+  ) => {
+    if (result.status === 'fulfilled') {
+      if (result.value.error) {
+        console.error(`Erro ao ${context}:`, result.value.error);
+      }
+      return result.value.data ?? null;
+    } else {
+      console.error(`Erro ao ${context}:`, result.reason);
+      return null;
+    }
+  };
+
+  const rpcData = resolveResult(rpcResult, 'chamar get_my_profile');
+  if (rpcData) return rpcData;
+
+  return resolveResult(tableResult, 'buscar user_profiles');
+}


### PR DESCRIPTION
## Summary
- extract profile loading into a reusable function
- handle concurrent RPC/fallback calls with Promise.allSettled
- add tests covering RPC errors and fallback behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f36ef800832a851c1142da915db1