### PR TITLE
feat: handle missing PIX webhook secret

### DIFF
--- a/supabase/functions/pix-webhook/handler.ts
+++ b/supabase/functions/pix-webhook/handler.ts
@@ -1,0 +1,68 @@
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-pix-signature",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, "0")).join("");
+}
+
+export function createHandler(secret?: string) {
+  return async function (req: Request): Promise<Response> {
+    if (req.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "method not allowed" }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!secret) {
+      console.error("pix-webhook missing PIX_WEBHOOK_SECRET");
+      return new Response(JSON.stringify({ error: "missing PIX_WEBHOOK_SECRET" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    try {
+      const signature = req.headers.get("x-pix-signature") || "";
+      const body = await req.text();
+
+      const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+      const expected = toHex(mac);
+
+      if (signature !== expected) {
+        return new Response(JSON.stringify({ error: "invalid signature" }), {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+
+      const payload = JSON.parse(body);
+      console.log("pix-webhook", payload);
+
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    } catch (e) {
+      return new Response(JSON.stringify({ error: String((e as any)?.message || e) }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+  };
+}
+
+export type PixWebhookHandler = ReturnType<typeof createHandler>;

--- a/supabase/functions/pix-webhook/index.ts
+++ b/supabase/functions/pix-webhook/index.ts
@@ -1,60 +1,6 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createHandler } from "./handler.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-pix-signature",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+const WEBHOOK_SECRET = Deno.env.get("PIX_WEBHOOK_SECRET");
 
-const WEBHOOK_SECRET = Deno.env.get("PIX_WEBHOOK_SECRET") || "";
-
-function toHex(buffer: ArrayBuffer): string {
-  return Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, "0")).join("");
-}
-
-serve(async (req: Request) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  if (req.method !== "POST") {
-    return new Response(JSON.stringify({ error: "method not allowed" }), {
-      status: 405,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-
-  try {
-    const signature = req.headers.get("x-pix-signature") || "";
-    const body = await req.text();
-
-    const key = await crypto.subtle.importKey(
-      "raw",
-      new TextEncoder().encode(WEBHOOK_SECRET),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"],
-    );
-    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
-    const expected = toHex(mac);
-
-    if (signature !== expected) {
-      return new Response(JSON.stringify({ error: "invalid signature" }), {
-        status: 401,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
-    }
-
-    const payload = JSON.parse(body);
-    console.log("pix-webhook", payload);
-
-    return new Response(JSON.stringify({ ok: true }), {
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  } catch (e) {
-    return new Response(JSON.stringify({ error: String((e as any)?.message || e) }), {
-      status: 500,
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
-  }
-});
+serve(createHandler(WEBHOOK_SECRET));

--- a/test/pix-webhook.test.ts
+++ b/test/pix-webhook.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { createHandler } from "../supabase/functions/pix-webhook/handler.ts";
+
+describe("pix-webhook", () => {
+  it("returns 500 when PIX_WEBHOOK_SECRET is missing", async () => {
+    const handler = createHandler(undefined);
+    const req = new Request("https://example.com", { method: "POST", body: "{}" });
+    const res = await handler(req);
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor pix-webhook function and ensure missing secret results in 500 with clear log
- add unit test for missing PIX_WEBHOOK_SECRET

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f881c218832a9c86e4e70df25081