### PR TITLE
Refactor lotes_geojson to expose only preco

### DIFF
--- a/NovoSetup/sql/sql.final.referenciado.sql
+++ b/NovoSetup/sql/sql.final.referenciado.sql
@@ -410,8 +410,7 @@ as $$
         'nome', l.nome,
         'numero', l.numero,
         'status', l.status,
-        'valor', l.valor,
-        'preco', l.valor,
+        'preco', coalesce(l.preco, l.valor),
         'area_m2', l.area_m2
       )
     ) as f

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -14,6 +14,7 @@ export interface LoteProperties {
   nome?: string;
   label?: string;
   description?: string;
+  preco?: number;
   [key: string]: unknown;
 }
 
@@ -22,6 +23,7 @@ export interface LoteData<P extends LoteProperties = LoteProperties> {
   nome: string;
   numero: number;
   area_m2: number;
+  preco?: number;
   coordenadas: { lat: number; lng: number };
   geometria: number[][][];
   properties: P;

--- a/supabase/rpc/lotes_geojson.sql
+++ b/supabase/rpc/lotes_geojson.sql
@@ -12,8 +12,7 @@ as $$
         'nome', l.nome,
         'numero', l.numero,
         'status', l.status,
-        'valor', l.valor,
-        'preco', l.valor,
+        'preco', coalesce(l.preco, l.valor),
         'area_m2', l.area_m2
       )
     ) as f


### PR DESCRIPTION
## Summary
- remove duplicated valor field from lotes_geojson RPC
- document preco field in lot types
- sync setup SQL with updated RPC definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4fa008fd0832aaa5af2a586b106d7