### PR TITLE
Ajusta tipos e status em vendas e cobranças

### DIFF
--- a/supabase/migrations/20250601000000_create_vendas.sql
+++ b/supabase/migrations/20250601000000_create_vendas.sql
@@ -3,8 +3,8 @@ create table if not exists public.vendas (
     lote_id uuid not null references public.lotes(id) on delete cascade,
     filial_id uuid not null references public.filiais(id) on delete cascade,
     corretor_id uuid not null references auth.users(id) on delete cascade,
-    valor numeric not null,
-    comissao numeric not null,
+    valor numeric(12,2) not null,
+    comissao numeric(12,2) not null,
     created_at timestamptz default now()
 );
 

--- a/supabase/migrations/20250803000000_create_cobrancas.sql
+++ b/supabase/migrations/20250803000000_create_cobrancas.sql
@@ -2,9 +2,10 @@ create table if not exists public.cobrancas (
     id uuid primary key default gen_random_uuid(),
     user_id uuid not null references auth.users(id) on delete cascade,
     filial_id uuid not null references public.filiais(id) on delete cascade,
-    valor numeric not null,
+    valor numeric(12,2) not null,
     status text not null default 'pendente',
-    created_at timestamptz default now()
+    created_at timestamptz default now(),
+    constraint cobrancas_status_check check (status in ('pendente','pago','cancelado'))
 );
 
 create index if not exists idx_cobrancas_user on public.cobrancas(user_id);

--- a/supabase/migrations/20250902000000_adjust_vendas_cobrancas.sql
+++ b/supabase/migrations/20250902000000_adjust_vendas_cobrancas.sql
@@ -1,0 +1,20 @@
+-- Adjust numeric precision and enforce status constraint
+
+-- Round existing values to two decimal places
+update public.vendas set valor = round(valor::numeric, 2), comissao = round(comissao::numeric, 2);
+update public.cobrancas set valor = round(valor::numeric, 2);
+
+-- Normalize status values
+update public.cobrancas set status = 'pendente' where status not in ('pendente','pago','cancelado');
+
+-- Alter column types to numeric(12,2)
+alter table public.vendas
+  alter column valor type numeric(12,2),
+  alter column comissao type numeric(12,2);
+
+alter table public.cobrancas
+  alter column valor type numeric(12,2);
+
+-- Add check constraint for status
+alter table public.cobrancas
+  add constraint if not exists cobrancas_status_check check (status in ('pendente','pago','cancelado'));


### PR DESCRIPTION
## Summary
- define `numeric(12,2)` para valores e comissões em vendas e cobranças
- restringe `status` de cobranças com constraint
- migração para adequar dados existentes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a509e68350832a94988052c476a28b