### PR TITLE
Handle lot reservation concurrency with security definer

### DIFF
--- a/MANUAL_RLS_TESTS.md
+++ b/MANUAL_RLS_TESTS.md
@@ -18,5 +18,9 @@ These steps verify that row level security policies based on `filial_id` prevent
    - Authenticated as `user_b`, attempt to `update` a row belonging to `filial_a` and confirm it fails.
 5. **Masterplan overlays and lotes**
    - Repeat similar `select` and `insert` tests on `lotes` and `masterplan_overlays` ensuring cross-filial access is denied.
+6. **Reservas e concorrência**
+   - Confirme que as tabelas `lotes` e `reservas` têm RLS habilitado com políticas usando `filial_id` do JWT.
+   - A função `reservar_lote` roda como `security definer`, mas depende dessas políticas para restringir acesso entre filiais.
+   - Para validar, tente reservar o mesmo `lote_id` simultaneamente em duas sessões; apenas uma deve obter `success = true`.
 
 Document the observed results for future reference.

--- a/supabase/migrations/20250903000000_reservar_lote_security.sql
+++ b/supabase/migrations/20250903000000_reservar_lote_security.sql
@@ -1,3 +1,5 @@
+-- Ensure reservar_lote uses security definer and has execute privileges
+
 create or replace function public.reservar_lote(
   p_lote_id uuid,
   p_ttl integer default 300
@@ -39,3 +41,5 @@ exception
     return next;
 end;
 $$;
+
+grant execute on function public.reservar_lote(uuid, integer) to authenticated;

--- a/test/reservar_lote.concurrent.test.ts
+++ b/test/reservar_lote.concurrent.test.ts
@@ -1,0 +1,38 @@
+import { createClient } from '@supabase/supabase-js';
+import { describe, it, expect } from 'vitest';
+
+const url = process.env.VITE_SUPABASE_URL;
+const anon = process.env.VITE_SUPABASE_ANON_KEY;
+const service = process.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
+const loteId = process.env.TEST_LOTE_ID;
+
+if (!url || !anon || !service || !loteId) {
+  describe.skip('reservar_lote concurrency', () => {
+    /* missing environment variables */
+  });
+} else {
+  const supabase = createClient(url, anon);
+  const admin = createClient(url, service, { auth: { persistSession: false } });
+
+  describe('reservar_lote concurrency', () => {
+    it('only allows one reservation for a lot', async () => {
+      await admin
+        .from('lotes')
+        .update({ status: 'disponivel', reserva_expira_em: null })
+        .eq('id', loteId);
+
+      const [a, b] = await Promise.all([
+        supabase.rpc('reservar_lote', { p_lote_id: loteId, p_ttl: 60 }),
+        supabase.rpc('reservar_lote', { p_lote_id: loteId, p_ttl: 60 }),
+      ]);
+
+      const successes = [a.data?.success, b.data?.success].filter(Boolean);
+      expect(successes).toHaveLength(1);
+
+      await admin
+        .from('lotes')
+        .update({ status: 'disponivel', reserva_expira_em: null })
+        .eq('id', loteId);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- run reservar_lote as SECURITY DEFINER and wrap updates in exception block
- document RLS requirements for lot reservations
- add concurrent reservation test and grant execute permission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a50bd797a4832a8da93e031659482c