### PR TITLE
Unify client panel into investor

### DIFF
--- a/NovoSetup/scripts/direct-database-fixes.js
+++ b/NovoSetup/scripts/direct-database-fixes.js
@@ -78,7 +78,7 @@ async function directFixes() {
             password: 'BlockUrb2024!',
             full_name: 'Super Administrador',
             role: 'superadmin',
-            panels: ['superadmin', 'adminfilial', 'cliente']
+            panels: ['superadmin', 'adminfilial']
           },
           {
             email: 'admin@blockurb.com',

--- a/NovoSetup/scripts/supabase-complete-setup.js
+++ b/NovoSetup/scripts/supabase-complete-setup.js
@@ -64,7 +64,7 @@ async function completeSupabaseSetup() {
         password: 'BlockUrb2024!',
         full_name: 'Super Administrador',
         role: 'superadmin',
-        panels: ['superadmin', 'adminfilial', 'urbanista', 'juridico', 'contabilidade', 'marketing', 'comercial', 'imobiliaria', 'corretor', 'obras', 'investidor', 'terrenista', 'cliente']
+        panels: ['superadmin', 'adminfilial', 'urbanista', 'juridico', 'contabilidade', 'marketing', 'comercial', 'imobiliaria', 'corretor', 'obras', 'investidor', 'terrenista']
       },
       {
         email: 'admin@blockurb.com',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ import WidgetTelemetryPage from "./pages/admin/WidgetTelemetry";
 import PublicWidgetPage from "./pages/public/Widget";
 import { publicWidgetEnabled } from "@/config/publicWidget";
 import RenegociacoesPage from "./pages/juridico/Renegociacoes";
-import ClienteCobrancasPage from "./pages/cliente/Cobrancas";
+import InvestidorCobrancasPage from "./pages/investidor/Cobrancas";
 import InvestidorExtratosPage from "./pages/investidor/Extratos";
 import TerrenistaExtratosPage from "./pages/terrenista/Extratos";
 
@@ -187,6 +187,7 @@ const App = () => (
             <Route path="/investidor/relatorios" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Relatórios" /></Protected>} />
             <Route path="/investidor/config" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Configurações" /></Protected>} />
             <Route path="/investidor/extratos" element={<Protected allowedRoles={['investidor']}><InvestidorExtratosPage /></Protected>} />
+            <Route path="/investidor/cobrancas" element={<Protected allowedRoles={['investidor']}><InvestidorCobrancasPage /></Protected>} />
             <Route path="/investidor/carteira" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Carteira" /></Protected>} />
             <Route path="/investidor/suporte" element={<Protected allowedRoles={['investidor']}><PanelSectionPage menuKey="investidor" title="Investidor" section="Suporte" /></Protected>} />
 
@@ -197,11 +198,6 @@ const App = () => (
             <Route path="/terrenista/extratos" element={<Protected allowedRoles={['terrenista']}><TerrenistaExtratosPage /></Protected>} />
             <Route path="/terrenista/status" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Status" /></Protected>} />
             <Route path="/terrenista/pagamentos" element={<Protected allowedRoles={['terrenista']}><PanelSectionPage menuKey="terrenista" title="Terrenista" section="Pagamentos" /></Protected>} />
-
-            {/* Cliente */}
-            <Route path="/cliente" element={<Protected allowedRoles={['cliente']}><PanelHomePage menuKey="cliente" title="Cliente" /></Protected>} />
-            <Route path="/cliente/extrato" element={<Protected allowedRoles={['cliente']}><PanelSectionPage menuKey="cliente" title="Cliente" section="Extrato" /></Protected>} />
-            <Route path="/cliente/cobrancas" element={<Protected allowedRoles={['cliente']}><ClienteCobrancasPage /></Protected>} />
 
             {/* Debug route */}
               <Route

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -11,7 +11,6 @@ export const scopeRoutes = {
   obras: "/obras",
   investidor: "/investidor",
   terrenista: "/terrenista",
-  cliente: "/cliente",
 } as const;
 
 export type AuthScope = keyof typeof scopeRoutes;
@@ -31,7 +30,6 @@ const scopeLabels: Record<AuthScope, string> = {
   obras: "Obras",
   investidor: "Investidor",
   terrenista: "Terrenista",
-  cliente: "Cliente",
 };
 
 export function labelFromScope(scope?: string | null): string | undefined {

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -78,16 +78,12 @@ export const NAV: Record<string, NavItem[]> = {
   investidor: [
     { title: "Investidor", href: "/investidor", icon: "line-chart" },
     { title: "Extratos", href: "/investidor/extratos", icon: "file-text" },
+    { title: "Cobranças", href: "/investidor/cobrancas", icon: "dollar-sign" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
   terrenista: [
     { title: "Terrenista", href: "/terrenista", icon: "landmark" },
     { title: "Extratos", href: "/terrenista/extratos", icon: "file-text" },
-    { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
-  ],
-  cliente: [
-    { title: "Extrato", href: "/cliente/extrato", icon: "file-text" },
-    { title: "Cobranças", href: "/cliente/cobrancas", icon: "dollar-sign" },
     { title: "Em Desenvolvimento", href: "#", icon: "wrench" },
   ],
 };

--- a/src/pages/cliente/Extrato.tsx
+++ b/src/pages/cliente/Extrato.tsx
@@ -1,5 +1,0 @@
-import { PanelSectionPage } from "@/components/panels/PanelPages";
-
-export default function ClienteExtratoPage() {
-  return <PanelSectionPage menuKey="cliente" title="Cliente" section="Extrato" />;
-}

--- a/src/pages/investidor/Cobrancas.tsx
+++ b/src/pages/investidor/Cobrancas.tsx
@@ -5,7 +5,7 @@ import { supabase } from "@/lib/dataClient";
 import { supabaseRequest } from "@/lib/request";
 import { useAuth } from "@/hooks/useAuth";
 
-export default function ClienteCobrancasPage() {
+export default function InvestidorCobrancasPage() {
   const { user } = useAuth();
   const [rows, setRows] = useState<Record<string, any>[]>([]);
   const [columns, setColumns] = useState<Column[]>([]);
@@ -31,8 +31,8 @@ export default function ClienteCobrancasPage() {
 
   return (
     <AppShell
-      menuKey="cliente"
-      breadcrumbs={[{ label: "Cliente", href: "/cliente" }, { label: "Cobranças" }]}
+      menuKey="investidor"
+      breadcrumbs={[{ label: "Investidor", href: "/investidor" }, { label: "Cobranças" }]}
     >
       <DataTable columns={columns} rows={rows} pageSize={5} />
     </AppShell>


### PR DESCRIPTION
## Summary
- Move client charges page into investor panel
- Drop separate client routes and role references
- Default signups and setup scripts use `investidor` role

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a50e862fbc832aa18d5c5ca6687e8f