### PR TITLE
Allow superadmin to access all routes

### DIFF
--- a/src/components/Protected.test.tsx
+++ b/src/components/Protected.test.tsx
@@ -40,6 +40,22 @@ describe('Protected component', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('allows superadmin even when not explicitly allowed', () => {
+    mockUseAuth.mockReturnValue({ session: {}, loading: false });
+    mockUseAuthorization.mockReturnValue({ profile: { role: 'superadmin', panels: [] }, loading: false });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Protected allowedRoles={['admin']}>
+          <div>Super Allowed</div>
+        </Protected>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Super Allowed')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('redirects when role is denied', async () => {
     mockUseAuth.mockReturnValue({ session: {}, loading: false });
     mockUseAuthorization.mockReturnValue({ profile: { role: 'user', panels: [] }, loading: false });

--- a/src/components/Protected.tsx
+++ b/src/components/Protected.tsx
@@ -18,6 +18,7 @@ function useRequiresLogin(session: unknown, loading: boolean) {
 function useRoleDenied(allowedRoles: string[] | undefined, profile: any) {
   return useMemo(() => {
     if (!allowedRoles?.length || !profile) return false;
+    if (profile.role === "superadmin") return false;
     return !allowedRoles.includes(profile.role);
   }, [allowedRoles, profile]);
 }


### PR DESCRIPTION
## Summary
- allow superadmin to bypass role-based restrictions in `Protected` component
- test that superadmin is always permitted

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a53d9fc550832a9d320d62f8849172