### PR TITLE
feat: add default dev login credentials

### DIFF
--- a/LOGIN_RAPIDO_IMPLEMENTADO.md
+++ b/LOGIN_RAPIDO_IMPLEMENTADO.md
@@ -32,17 +32,16 @@ Implementei botões de **Login Rápido** em todos os pontos de acesso do sistema
 ### 🏢 **Usuários Especializados**
 | Usuário | Email | Senha | Painel |
 |---------|-------|-------|---------|
-| **Admin Filial** | `admin@blockurb.com` | `Admin2024!` | `/admin` |
-| **Urbanista** | `urbanista@blockurb.com` | `Urban2024!` | `/urbanista` |
-| **Jurídico** | `juridico@blockurb.com` | `Legal2024!` | `/juridico` |
-| **Contabilidade** | `contabilidade@blockurb.com` | `Conta2024!` | `/contabilidade` |
-| **Marketing** | `marketing@blockurb.com` | `Market2024!` | `/marketing` |
-| **Comercial** | `comercial@blockurb.com` | `Venda2024!` | `/comercial` |
-| **Imobiliária** | `imobiliaria@blockurb.com` | `Imob2024!` | `/imobiliaria` |
-| **Corretor** | `corretor@blockurb.com` | `Corret2024!` | `/corretor` |
-| **Obras** | `obras@blockurb.com` | `Obras2024!` | `/obras` |
-| **Investidor** | `investidor@blockurb.com` | `Invest2024!` | `/investidor` |
-| **Terrenista** | `terrenista@blockurb.com` | `Terra2024!` | `/terrenista` |
+| **Admin Filial** | `filial@blockurb.com` | `123` | `/admin` |
+| **Urbanista** | `urbanista@blockurb.com` | `123` | `/urbanista` |
+| **Jurídico** | `juridico@blockurb.com` | `123` | `/juridico` |
+| **Contabilidade** | `contabilidade@blockurb.com` | `123` | `/contabilidade` |
+| **Marketing** | `marketing@blockurb.com` | `123` | `/marketing` |
+| **Comercial** | `comercial@blockurb.com` | `123` | `/comercial` |
+| **Imobiliária** | `imobiliaria@blockurb.com` | `123` | `/imobiliaria` |
+| **Corretor** | `corretor@blockurb.com` | `123` | `/corretor` |
+| **Obras** | `obras@blockurb.com` | `123` | `/obras` |
+| **Terrenista** | `terrenista@blockurb.com` | `123` | `/terrenista` |
 
 ## 🎨 **Interface dos Botões**
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,28 @@ The quick login widget can load test accounts from environment variables. Create
 ```
 VITE_SUPERADMIN_EMAIL=superadmin@example.com
 VITE_SUPERADMIN_PASSWORD=strong-password
-VITE_ADMIN_EMAIL=admin@example.com
+VITE_ADMIN_EMAIL=filial@example.com
 VITE_ADMIN_PASSWORD=strong-password
 # repeat for other roles using the pattern
 # VITE_<ROLE>_EMAIL and VITE_<ROLE>_PASSWORD
 ```
 
 Only roles with both variables defined will appear in the widget.
+
+When no environment variables are set in development, the widget exposes default test accounts:
+
+| Role | Email | Password |
+|------|-------|----------|
+| Admin Filial | `filial@blockurb.com` | `123` |
+| Urbanista | `urbanista@blockurb.com` | `123` |
+| Jurídico | `juridico@blockurb.com` | `123` |
+| Contabilidade | `contabilidade@blockurb.com` | `123` |
+| Marketing | `marketing@blockurb.com` | `123` |
+| Comercial | `comercial@blockurb.com` | `123` |
+| Imobiliária | `imobiliaria@blockurb.com` | `123` |
+| Corretor | `corretor@blockurb.com` | `123` |
+| Terrenista | `terrenista@blockurb.com` | `123` |
+| Obras | `obras@blockurb.com` | `123` |
 
 This quick login widget is available only during development and returns nothing in production builds.
 

--- a/USUARIOS_E_CREDENCIAIS.md
+++ b/USUARIOS_E_CREDENCIAIS.md
@@ -17,69 +17,69 @@
 ## 🏢 Painéis Administrativos
 
 ### Administrador Filial
-**Email:** `admin@blockurb.com`  
-**Senha:** `Admin2024!`  
-**Painel:** `/adminfilial` ou `/admin`  
+**Email:** `filial@blockurb.com`
+**Senha:** `123`
+**Painel:** `/adminfilial` ou `/admin`
 **Funcionalidades:** Gestão geral da filial
 
 ### Urbanista
-**Email:** `urbanista@blockurb.com`  
-**Senha:** `Urban2024!`  
-**Painel:** `/urbanista`  
+**Email:** `urbanista@blockurb.com`
+**Senha:** `123`
+**Painel:** `/urbanista`
 **Funcionalidades:** Projetos urbanos e mapas
 
 ### Jurídico
-**Email:** `juridico@blockurb.com`  
-**Senha:** `Legal2024!`  
-**Painel:** `/juridico`  
+**Email:** `juridico@blockurb.com`
+**Senha:** `123`
+**Painel:** `/juridico`
 **Funcionalidades:** Contratos e processos
 
 ### Contabilidade
-**Email:** `contabilidade@blockurb.com`  
-**Senha:** `Conta2024!`  
-**Painel:** `/contabilidade`  
+**Email:** `contabilidade@blockurb.com`
+**Senha:** `123`
+**Painel:** `/contabilidade`
 **Funcionalidades:** Financeiro e fiscal
 
 ### Marketing
-**Email:** `marketing@blockurb.com`  
-**Senha:** `Market2024!`  
-**Painel:** `/marketing`  
+**Email:** `marketing@blockurb.com`
+**Senha:** `123`
+**Painel:** `/marketing`
 **Funcionalidades:** Campanhas e materiais
 
 ### Comercial
-**Email:** `comercial@blockurb.com`  
-**Senha:** `Venda2024!`  
-**Painel:** `/comercial`  
+**Email:** `comercial@blockurb.com`
+**Senha:** `123`
+**Painel:** `/comercial`
 **Funcionalidades:** Leads e propostas
 
 ### Imobiliária
-**Email:** `imobiliaria@blockurb.com`  
-**Senha:** `Imob2024!`  
-**Painel:** `/imobiliaria`  
+**Email:** `imobiliaria@blockurb.com`
+**Senha:** `123`
+**Painel:** `/imobiliaria`
 **Funcionalidades:** Corretores e leads
 
 ### Corretor
-**Email:** `corretor@blockurb.com`  
-**Senha:** `Corret2024!`  
-**Painel:** `/corretor`  
+**Email:** `corretor@blockurb.com`
+**Senha:** `123`
+**Painel:** `/corretor`
 **Funcionalidades:** Leads e vendas
 
 ### Obras
-**Email:** `obras@blockurb.com`  
-**Senha:** `Obras2024!`  
-**Painel:** `/obras`  
+**Email:** `obras@blockurb.com`
+**Senha:** `123`
+**Painel:** `/obras`
 **Funcionalidades:** Cronograma e andamento
 
 ### Investidor
-**Email:** `investidor@blockurb.com`  
-**Senha:** `Invest2024!`  
-**Painel:** `/investidor`  
+**Email:** `investidor@blockurb.com`
+**Senha:** `Invest2024!`
+**Painel:** `/investidor`
 **Funcionalidades:** Carteira e suporte
 
 ### Terrenista
-**Email:** `terrenista@blockurb.com`  
-**Senha:** `Terra2024!`  
-**Painel:** `/terrenista`  
+**Email:** `terrenista@blockurb.com`
+**Senha:** `123`
+**Painel:** `/terrenista`
 **Funcionalidades:** Status e pagamentos
 
 ## 🗺️ Funcionalidades Especiais

--- a/src/config/quickLogin.ts
+++ b/src/config/quickLogin.ts
@@ -33,10 +33,24 @@ const configs: QuickLoginConfig[] = [
 ];
 const env = import.meta.env as Record<string, string | undefined>;
 
+const devDefaults: Record<string, { email: string; password: string }> = {
+  ADMIN: { email: "filial@blockurb.com", password: "123" },
+  URBANISTA: { email: "urbanista@blockurb.com", password: "123" },
+  JURIDICO: { email: "juridico@blockurb.com", password: "123" },
+  CONTABILIDADE: { email: "contabilidade@blockurb.com", password: "123" },
+  MARKETING: { email: "marketing@blockurb.com", password: "123" },
+  COMERCIAL: { email: "comercial@blockurb.com", password: "123" },
+  IMOBILIARIA: { email: "imobiliaria@blockurb.com", password: "123" },
+  CORRETOR: { email: "corretor@blockurb.com", password: "123" },
+  TERRENISTA: { email: "terrenista@blockurb.com", password: "123" },
+  OBRAS: { email: "obras@blockurb.com", password: "123" }
+};
+
 export const quickLoginCredentials: QuickLoginCredential[] = configs
   .map((cfg) => {
-    const email = env[`VITE_${cfg.envPrefix}_EMAIL`];
-    const password = env[`VITE_${cfg.envPrefix}_PASSWORD`];
+    const defaults = import.meta.env.DEV ? devDefaults[cfg.envPrefix] : undefined;
+    const email = env[`VITE_${cfg.envPrefix}_EMAIL`] ?? defaults?.email;
+    const password = env[`VITE_${cfg.envPrefix}_PASSWORD`] ?? defaults?.password;
 
     if (!email || !password) return null;
 


### PR DESCRIPTION
## Summary
- add built-in quick login accounts for development
- document default emails and password `123`
- update user credential docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5463c29ec832a995f7523dc729af4