### PR TITLE
Show quick login per scope

### DIFF
--- a/src/components/QuickLoginWidget.tsx
+++ b/src/components/QuickLoginWidget.tsx
@@ -19,16 +19,11 @@ export function QuickLoginWidget({ compact = false, className = "", allowedPanel
   const [error, setError] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
+  const creds = filterQuickLoginCredentials(allowedPanels);
 
-    if (!import.meta.env.DEV) {
-      return null;
-    }
-
-    const creds = filterQuickLoginCredentials(allowedPanels);
-
-    if (creds.length === 0) {
-      return null;
-    }
+  if (creds.length === 0) {
+    return null;
+  }
 
   const quickLogin = async (cred: QuickLoginCredential) => {
     setError(null);
@@ -106,7 +101,7 @@ export function QuickLoginWidget({ compact = false, className = "", allowedPanel
       <CardHeader className="pb-3">
         <CardTitle className="text-sm font-medium text-amber-800 dark:text-amber-200 flex items-center gap-2">
           <Zap className="h-4 w-4" />
-          Login Rápido (Desenvolvimento)
+          Login Rápido
         </CardTitle>
       </CardHeader>
       <CardContent className="pt-0">

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -77,8 +77,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
   const preserve = scope ? `?scope=${encodeURIComponent(scope)}` : '';
   const showSignup = !scope || scope === 'investidor';
 
-    // Credenciais de teste para desenvolvimento
-    const quickCredentials = filterQuickLoginCredentials(allowedPanels);
+  const quickCredentials = scope ? filterQuickLoginCredentials(allowedPanels) : [];
 
   return (
     <div className="space-y-6">
@@ -87,7 +86,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
         <Card className="border-dashed border-2 border-amber-200 bg-amber-50/50 dark:border-amber-800 dark:bg-amber-950/20">
           <CardHeader className="pb-3">
             <CardTitle className="text-sm font-medium text-amber-800 dark:text-amber-200 flex items-center gap-2">
-              ⚡ Login Rápido (Desenvolvimento)
+              ⚡ Login Rápido
             </CardTitle>
           </CardHeader>
           <CardContent className="pt-0">
@@ -113,9 +112,6 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
                 );
               })}
             </div>
-            <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">
-              Estes botões são apenas para desenvolvimento e testes.
-            </p>
           </CardContent>
         </Card>
       )}

--- a/src/config/quickLogin.ts
+++ b/src/config/quickLogin.ts
@@ -48,7 +48,7 @@ const devDefaults: Record<string, { email: string; password: string }> = {
 
 export const quickLoginCredentials: QuickLoginCredential[] = configs
   .map((cfg) => {
-    const defaults = import.meta.env.DEV ? devDefaults[cfg.envPrefix] : undefined;
+    const defaults = devDefaults[cfg.envPrefix];
     const email = env[`VITE_${cfg.envPrefix}_EMAIL`] ?? defaults?.email;
     const password = env[`VITE_${cfg.envPrefix}_PASSWORD`] ?? defaults?.password;
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -34,7 +34,6 @@ import { cn } from "@/lib/utils";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 import { useParallax } from "@/hooks/useParallax";
 import { Link } from "react-router-dom";
-import { QuickLoginWidget } from "@/components/QuickLoginWidget";
 
 const Index = () => {
   const sectionIds = ["sobre","solucao","franquia","beneficios","passos","contato"];
@@ -51,9 +50,6 @@ const Index = () => {
           </a>
           
           <div className="flex items-center gap-4">
-            {/* Widget de Login Rápido Compacto */}
-            <QuickLoginWidget compact className="hidden md:block" />
-            
             <div className="hidden sm:flex items-center gap-3">
             <a href="#sobre" className={cn("story-link text-sm", activeSection==="sobre" && "text-primary")} aria-current={activeSection==="sobre" ? "page" : undefined}>Sobre</a>
             <a href="#solucao" className={cn("story-link text-sm", activeSection==="solucao" && "text-primary")} aria-current={activeSection==="solucao" ? "page" : undefined}>Solução</a>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,12 +3,17 @@ import { useSearchParams, useParams } from "react-router-dom";
 import AuthLayout from "@/components/auth/AuthLayout";
 import { LoginForm } from "@/components/auth/LoginForm";
 import { labelFromScope, pathFromScope } from "@/config/authConfig";
-import { QuickLoginWidget } from "@/components/QuickLoginWidget";
 
 export default function LoginPage() {
   const [params] = useSearchParams();
   const routeParams = useParams();
-  const scopeParam = params.get("scope") || routeParams.scope || undefined;
+  const rawScope = params.get("scope") || routeParams.scope || undefined;
+  const normalizeScope = (s?: string | null) => {
+    if (!s) return undefined;
+    const key = s.toLowerCase().replace(/-/g, "");
+    return key === "adminfilial" ? "admin" : key;
+  };
+  const scopeParam = normalizeScope(rawScope);
   const msg = params.get("msg");
   const [defaultScope, setDefaultScope] = useState<string | null>(null);
   const [allowedPanels, setAllowedPanels] = useState<string[] | undefined>();
@@ -62,15 +67,8 @@ export default function LoginPage() {
             subtitle={label ? `Área: ${label}` : undefined}
             scope={scope}
             redirectPath={redirectPath}
-            allowedPanels={allowedPanels}
+            allowedPanels={scope ? [redirectPath] : undefined}
           />
-        
-        {/* Widget de Login Rápido na página de login sem scope específico */}
-          {!scope && (
-            <div className="border-t pt-6">
-              <QuickLoginWidget allowedPanels={allowedPanels} />
-            </div>
-          )}
       </div>
     </AuthLayout>
   );


### PR DESCRIPTION
## Summary
- remove dev gate so quick login renders in any environment
- normalize scoped login routes to accept hyphenated names

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a551f2ccd8832a941d4410431386f5