### PR TITLE
refactor: rename admin scope to adminfilial

### DIFF
--- a/src/components/Protected.test.tsx
+++ b/src/components/Protected.test.tsx
@@ -26,11 +26,11 @@ afterEach(() => {
 describe('Protected component', () => {
   it('renders children when access is allowed', () => {
     mockUseAuth.mockReturnValue({ session: {}, loading: false });
-    mockUseAuthorization.mockReturnValue({ profile: { role: 'admin', panels: ['dashboard'] }, loading: false });
+    mockUseAuthorization.mockReturnValue({ profile: { role: 'adminfilial', panels: ['dashboard'] }, loading: false });
 
     render(
       <MemoryRouter initialEntries={['/']}>
-        <Protected allowedRoles={['admin']} panelKey="dashboard">
+        <Protected allowedRoles={['adminfilial']} panelKey="dashboard">
           <div>Allowed</div>
         </Protected>
       </MemoryRouter>
@@ -46,7 +46,7 @@ describe('Protected component', () => {
 
     render(
       <MemoryRouter initialEntries={['/']}>
-        <Protected allowedRoles={['admin']}>
+        <Protected allowedRoles={['adminfilial']}>
           <div>Super Allowed</div>
         </Protected>
       </MemoryRouter>
@@ -62,7 +62,7 @@ describe('Protected component', () => {
 
     render(
       <MemoryRouter initialEntries={['/']}>
-        <Protected allowedRoles={['admin']}>
+        <Protected allowedRoles={['adminfilial']}>
           <div>Denied</div>
         </Protected>
       </MemoryRouter>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -40,7 +40,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || "/admin-filial");
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");
@@ -65,7 +65,7 @@ export function LoginForm({ title, subtitle, scope, redirectPath, allowedPanels 
       }
       
       if (res?.session) {
-        navigate(redirectPath || "/admin");
+        navigate(redirectPath || "/admin-filial");
       }
     } catch (err) {
       setError("Erro inesperado ao fazer login");

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -22,30 +22,30 @@ const sections = [
   {
     label: "Geral",
     items: [
-      { title: "Dashboard", url: "/admin", icon: LayoutDashboard },
-      { title: "Equipe", url: "/admin/equipe", icon: Users },
-      { title: "Leads", url: "/admin/leads", icon: Users },
-      { title: "Propostas", url: "/admin/propostas", icon: FileText },
+      { title: "Dashboard", url: "/admin-filial", icon: LayoutDashboard },
+      { title: "Equipe", url: "/admin-filial/equipe", icon: Users },
+      { title: "Leads", url: "/admin-filial/leads", icon: Users },
+      { title: "Propostas", url: "/admin-filial/propostas", icon: FileText },
     ],
   },
   {
     label: "Operação",
     items: [
-      { title: "Mapa", url: "/admin/mapa", icon: Map },
-      { title: "Obras", url: "/admin/obras", icon: Hammer },
+      { title: "Mapa", url: "/admin-filial/mapa", icon: Map },
+      { title: "Obras", url: "/admin-filial/obras", icon: Hammer },
     ],
   },
   {
     label: "Financeiro",
     items: [
-      { title: "Financeiro", url: "/admin/financeiro", icon: DollarSign },
-      { title: "Relatórios", url: "/admin/relatorios", icon: BarChart3 },
+      { title: "Financeiro", url: "/admin-filial/financeiro", icon: DollarSign },
+      { title: "Relatórios", url: "/admin-filial/relatorios", icon: BarChart3 },
     ],
   },
   {
     label: "Configurações",
     items: [
-      { title: "Configurações", url: "/admin/configuracoes", icon: Cog },
+      { title: "Configurações", url: "/admin-filial/configuracoes", icon: Cog },
     ],
   },
 ];

--- a/src/config/authConfig.ts
+++ b/src/config/authConfig.ts
@@ -1,6 +1,6 @@
 export const scopeRoutes = {
   superadmin: "/super-admin",
-  admin: "/admin-filial",
+  adminfilial: "/admin-filial",
   imobiliaria: "/imobiliaria",
   corretor: "/corretor",
   juridico: "/juridico",
@@ -19,7 +19,7 @@ export const AUTH_ROLES: AuthScope[] = Object.keys(scopeRoutes) as AuthScope[];
 
 const scopeLabels: Record<AuthScope, string> = {
   superadmin: "Super Admin",
-  admin: "Admin Filial",
+  adminfilial: "Admin Filial",
   imobiliaria: "Imobiliária",
   corretor: "Corretores",
   juridico: "Jurídico",

--- a/src/pages/Acesso.tsx
+++ b/src/pages/Acesso.tsx
@@ -17,7 +17,7 @@ import {
 
 const cards = [
   { title: "Painel Super Admin", desc: "Controle total da plataforma e permissões.", href: "/login/superadmin", Icon: Shield },
-  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/admin", Icon: Building2 },
+  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/admin-filial", Icon: Building2 },
   { title: "Painel Urbanista", desc: "Projetos, mapas e integrações GIS.", href: "/login/urbanista", Icon: Map },
   { title: "Painel Jurídico", desc: "Contratos e regularização fundiária.", href: "/login/juridico", Icon: ScrollText },
   { title: "Painel Contabilidade", desc: "Financeiro e relatórios fiscais.", href: "/login/contabilidade", Icon: Calculator },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,7 +11,7 @@ export default function LoginPage() {
   const normalizeScope = (s?: string | null) => {
     if (!s) return undefined;
     const key = s.toLowerCase().replace(/-/g, "");
-    return key === "adminfilial" ? "admin" : key;
+    return key === "admin" ? "adminfilial" : key;
   };
   const scopeParam = normalizeScope(rawScope);
   const msg = params.get("msg");
@@ -36,7 +36,7 @@ export default function LoginPage() {
 
     useEffect(() => {
       const host = window.location.host;
-      const mapPanelToScope = (p: string) => (p === 'adminfilial' ? 'admin' : p);
+      const mapPanelToScope = (p: string) => (p === 'admin' ? 'adminfilial' : p);
       const mapPanelToPath = (p: string) => pathFromScope(mapPanelToScope(p));
       fetch(`/resolve-domain?domain=${host}`)
         .then((res) => (res.ok ? res.json() : null))

--- a/src/pages/admin/MapaReal.tsx
+++ b/src/pages/admin/MapaReal.tsx
@@ -86,7 +86,7 @@ function SidebarEmpreendimentos({ onSelect, activeId }: { onSelect: (e: Empreend
               >
                 <div className="flex items-center justify-between">
                   <div className="font-medium text-sm">{e.nome}</div>
-                  <a href={`/admin?empreendimento=${e.id}`} onClick={(ev)=>ev.stopPropagation()} className="text-xs text-primary underline">Abrir no painel</a>
+                  <a href={`/admin-filial?empreendimento=${e.id}`} onClick={(ev)=>ev.stopPropagation()} className="text-xs text-primary underline">Abrir no painel</a>
                 </div>
                 <div className="mt-2 text-xs text-muted-foreground">
                   Criado em: {new Date(e.created_at).toLocaleDateString('pt-BR')}

--- a/src/providers/loadAuthorizationProfile.test.ts
+++ b/src/providers/loadAuthorizationProfile.test.ts
@@ -28,7 +28,7 @@ describe('loadAuthorizationProfile', () => {
         eq: () => ({
           maybeSingle: () =>
             Promise.resolve({
-              data: { role: 'admin', panels: ['dash'], filial_id: 1 },
+              data: { role: 'adminfilial', panels: ['dash'], filial_id: 1 },
               error: null,
             }),
         }),
@@ -37,7 +37,7 @@ describe('loadAuthorizationProfile', () => {
 
     const controller = new AbortController();
     const result = await loadAuthorizationProfile(userId, controller.signal);
-    expect(result).toEqual({ role: 'admin', panels: ['dash'], filial_id: 1 });
+    expect(result).toEqual({ role: 'adminfilial', panels: ['dash'], filial_id: 1 });
     expect(mockRpc).toHaveBeenCalled();
     expect(mockFrom).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- switch `admin` auth scope to `adminfilial` in config and labels
- normalize `admin` scope in login, redirecting to `/admin-filial`
- update tests and links for `adminfilial`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60c7ec074832a8cec110eab4fb4a5