### PR TITLE
refactor: handle adminfilial login scope

### DIFF
--- a/src/pages/Acesso.tsx
+++ b/src/pages/Acesso.tsx
@@ -17,7 +17,7 @@ import {
 
 const cards = [
   { title: "Painel Super Admin", desc: "Controle total da plataforma e permissões.", href: "/login/superadmin", Icon: Shield },
-  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/admin", Icon: Building2 },
+  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/adminfilial", Icon: Building2 },
   { title: "Painel Urbanista", desc: "Projetos, mapas e integrações GIS.", href: "/login/urbanista", Icon: Map },
   { title: "Painel Jurídico", desc: "Contratos e regularização fundiária.", href: "/login/juridico", Icon: ScrollText },
   { title: "Painel Contabilidade", desc: "Financeiro e relatórios fiscais.", href: "/login/contabilidade", Icon: Calculator },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -8,12 +8,8 @@ export default function LoginPage() {
   const [params] = useSearchParams();
   const routeParams = useParams();
   const rawScope = params.get("scope") || routeParams.scope || undefined;
-  const normalizeScope = (s?: string | null) => {
-    if (!s) return undefined;
-    const key = s.toLowerCase().replace(/-/g, "");
-    return key === "adminfilial" ? "admin" : key;
-  };
-  const scopeParam = normalizeScope(rawScope);
+  const normalize = (s: string) => s.toLowerCase().replace(/-/g, "");
+  const scopeParam = rawScope ? normalize(rawScope) : undefined;
   const msg = params.get("msg");
   const [defaultScope, setDefaultScope] = useState<string | null>(null);
   const [allowedPanels, setAllowedPanels] = useState<string[] | undefined>();
@@ -36,7 +32,7 @@ export default function LoginPage() {
 
     useEffect(() => {
       const host = window.location.host;
-      const mapPanelToScope = (p: string) => (p === 'adminfilial' ? 'admin' : p);
+      const mapPanelToScope = (p: string) => normalize(p);
       const mapPanelToPath = (p: string) => pathFromScope(mapPanelToScope(p));
       fetch(`/resolve-domain?domain=${host}`)
         .then((res) => (res.ok ? res.json() : null))


### PR DESCRIPTION
## Summary
- avoid normalizing adminfilial to admin in login scope handling
- update access card link to use /login/adminfilial

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60c9c89b8832aa10fe8886400a26d