### PR TITLE
refactor: remove adminfilial normalization

### DIFF
--- a/src/pages/Acesso.tsx
+++ b/src/pages/Acesso.tsx
@@ -17,7 +17,7 @@ import {
 
 const cards = [
   { title: "Painel Super Admin", desc: "Controle total da plataforma e permissões.", href: "/login/superadmin", Icon: Shield },
-  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/admin-filial", Icon: Building2 },
+  { title: "Painel Admin Filial", desc: "Gestão completa da filial e operações.", href: "/login/adminfilial", Icon: Building2 },
   { title: "Painel Urbanista", desc: "Projetos, mapas e integrações GIS.", href: "/login/urbanista", Icon: Map },
   { title: "Painel Jurídico", desc: "Contratos e regularização fundiária.", href: "/login/juridico", Icon: ScrollText },
   { title: "Painel Contabilidade", desc: "Financeiro e relatórios fiscais.", href: "/login/contabilidade", Icon: Calculator },

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -8,12 +8,7 @@ export default function LoginPage() {
   const [params] = useSearchParams();
   const routeParams = useParams();
   const rawScope = params.get("scope") || routeParams.scope || undefined;
-  const normalizeScope = (s?: string | null) => {
-    if (!s) return undefined;
-    const key = s.toLowerCase().replace(/-/g, "");
-    return key === "admin" ? "adminfilial" : key;
-  };
-  const scopeParam = normalizeScope(rawScope);
+  const scopeParam = rawScope?.toLowerCase().replace(/-/g, "") || undefined;
   const msg = params.get("msg");
   const [defaultScope, setDefaultScope] = useState<string | null>(null);
   const [allowedPanels, setAllowedPanels] = useState<string[] | undefined>();
@@ -36,7 +31,7 @@ export default function LoginPage() {
 
     useEffect(() => {
       const host = window.location.host;
-      const mapPanelToScope = (p: string) => (p === 'admin' ? 'adminfilial' : p);
+      const mapPanelToScope = (p: string) => p.toLowerCase().replace(/-/g, "");
       const mapPanelToPath = (p: string) => pathFromScope(mapPanelToScope(p));
       fetch(`/resolve-domain?domain=${host}`)
         .then((res) => (res.ok ? res.json() : null))


### PR DESCRIPTION
## Summary
- remove scope normalization that converted admin to adminfilial
- normalize panels by stripping dashes
- fix admin filial access card link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61353405c832aac2751771733b09f