### PR TITLE
Enable React Router v7 future flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,12 @@ const App = () => (
       <Toaster />
       <Sonner />
       <ProgressBar />
-      <BrowserRouter>
+      <BrowserRouter
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <AuthProvider>
           <AuthorizationProvider>
           <Routes>

--- a/src/components/Protected.test.tsx
+++ b/src/components/Protected.test.tsx
@@ -29,7 +29,13 @@ describe('Protected component', () => {
     mockUseAuthorization.mockReturnValue({ profile: { role: 'adminfilial', panels: ['dashboard'] }, loading: false });
 
     render(
-      <MemoryRouter initialEntries={['/']}>
+      <MemoryRouter
+        initialEntries={['/']}
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <Protected allowedRoles={['adminfilial']} panelKey="dashboard">
           <div>Allowed</div>
         </Protected>
@@ -45,7 +51,13 @@ describe('Protected component', () => {
     mockUseAuthorization.mockReturnValue({ profile: { role: 'superadmin', panels: [] }, loading: false });
 
     render(
-      <MemoryRouter initialEntries={['/']}>
+      <MemoryRouter
+        initialEntries={['/']}
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <Protected allowedRoles={['adminfilial']}>
           <div>Super Allowed</div>
         </Protected>
@@ -61,7 +73,13 @@ describe('Protected component', () => {
     mockUseAuthorization.mockReturnValue({ profile: { role: 'user', panels: [] }, loading: false });
 
     render(
-      <MemoryRouter initialEntries={['/']}>
+      <MemoryRouter
+        initialEntries={['/']}
+        future={{
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        }}
+      >
         <Protected allowedRoles={['adminfilial']}>
           <div>Denied</div>
         </Protected>


### PR DESCRIPTION
## Summary
- enable React Router v7 features with `future` flags
- update tests to opt-in to router v7 behavior and avoid warnings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a62199495c832a84fbd4791b474675