### PR TITLE
fix: add cobrancas status constraint

### DIFF
--- a/instalar/install.sql
+++ b/instalar/install.sql
@@ -2076,7 +2076,10 @@ alter table public.cobrancas
 
 -- Add check constraint for status
 alter table public.cobrancas
-  add constraint if not exists cobrancas_status_check check (status in ('pendente','pago','cancelado'));
+  drop constraint if exists cobrancas_status_check;
+
+alter table public.cobrancas
+  add constraint cobrancas_status_check check (status in ('pendente','pago','cancelado'));
 -- Ensure reservar_lote uses security definer and has execute privileges
 
 create or replace function public.reservar_lote(


### PR DESCRIPTION
## Summary
- ensure cobrancas status constraint is added without syntax errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa807fbebc832a98bddc3e9e9d09c3