### PR TITLE
fix: show adminfilial menu

### DIFF
--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -99,13 +99,14 @@ export function AppSidebar({ menuKey }: { menuKey?: string }) {
   const rawItems: NavItem[] = NAV[key] || [];
   const isSuperAdmin = profile?.role === 'superadmin';
   const panels = Array.isArray(profile?.panels) ? (profile?.panels as string[]) : [];
+  const allowedPanels = new Set([...panels, profile?.role]);
   const items = rawItems.filter((item) => {
     // Se não tiver panelKey, sempre mostra
     if (!item.panelKey) return true;
     // Super Admin sempre vê
     if (isSuperAdmin) return true;
-    // Somente mostra se o painel estiver permitido
-    return panels.includes(item.panelKey);
+    // Sempre permite o painel associado ao role do usuário
+    return allowedPanels.has(item.panelKey);
   });
 
   return (


### PR DESCRIPTION
## Summary
- always allow panel menu matching user role so admin-filial sees its items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa937e1b1c832a94071a7b209550c3